### PR TITLE
vlatai: fix detection of some lujvo as slinku'i

### DIFF
--- a/parsers/camxes_ilmen.peg
+++ b/parsers/camxes_ilmen.peg
@@ -1351,7 +1351,7 @@ vlatai = (
     / ZEI
     / vlatai_bu_clause
     / vlatai_zei_clause
-    / tosmabru / slinkuhi
+    / tosmabru / slinkuhi_no_recurse
     / ( non_bu_zei_cmavo+ )
     / BRIVLA
     / CMEVLA
@@ -1496,6 +1496,7 @@ fuhivla_head = ( !rafsi_string brivla_head )
 brivla_head = ( !cmavo !slinkuhi !h &onset unstressed_syllable* )
 
 slinkuhi = ( consonant rafsi_string )
+slinkuhi_no_recurse = ( !lujvo ( consonant rafsi_string ) )
 
 rafsi_string = (
   y_less_rafsi*

--- a/transformers/vlatai.py
+++ b/transformers/vlatai.py
@@ -20,7 +20,7 @@ class Visitor(camxes_morphology.Visitor):
   def visit_tosmabru(self, node, visited_children):
     return Tosmabru(flatten(visited_children))
 
-  def visit_slinkuhi(self, node, visited_children):
+  def visit_slinkuhi_no_recurse(self, node, visited_children):
     return Slinkuhi(flatten(visited_children))
 
   def visit_vlatai_bu_clause(self, node, visited_children):


### PR DESCRIPTION
Some lujvo (e.g. {cmakla}) were being detected as slinku'i. This is due to trying to positively match against the slinkuhi rule in vlatai, which is never done elsewhere in the grammar -- it's only used a negative lookahead.

Simply adding !lujvo to slinkuhi doesn't work, because it creates an infinite recursion. So I made another slinkuhi rule for vlatai to use, that only does the !lujvo check once.
