### PR TITLE
Lujvo: various features

### DIFF
--- a/camxes.py
+++ b/camxes.py
@@ -99,7 +99,10 @@ def do_parse(text, options):
                     text = 'valrx' + text
                     options.trim = 5
                 else:
-                    text = 'valr' + text
+                    if text[0] == 'r':
+                        text = 'valn' + text
+                    else:
+                        text = 'valr' + text
                     options.trim = 4
 
     parser = build_parser(options)

--- a/camxes.py
+++ b/camxes.py
@@ -91,13 +91,16 @@ def do_parse(text, options):
         if options.transformer in ('lujvo-break', 'lujvo-expand'):
             options.rule = 'lujvo'
         elif options.transformer == 'syllable':
-            options.rule = 'jbocme'
-            #options.rule = 'fuhivla'
-            if text[-1] not in 'bcdfgjklmnprstvxz':
-                text += 's'
-                options.trim = -1
-                #text = 'saskr' + text
-                #options.trim = 5
+            if text[-1] in 'bcdfgjklmnprstvxz':
+                options.rule = 'jbocme'
+            else:
+                options.rule = 'fuhivla'
+                if text[0] in 'aeiou':
+                    text = 'valrx' + text
+                    options.trim = 5
+                else:
+                    text = 'valr' + text
+                    options.trim = 4
 
     parser = build_parser(options)
     transformer = build_transformer(options, parser)

--- a/camxes.py
+++ b/camxes.py
@@ -91,19 +91,10 @@ def do_parse(text, options):
         if options.transformer in ('lujvo-break', 'lujvo-expand'):
             options.rule = 'lujvo'
         elif options.transformer == 'syllable':
-            if text[-1] in 'bcdfgjklmnprstvxz':
-                options.rule = 'cmevla'
-            else:
-                options.rule = 'fuhivla_any'
-                if text[0] in 'aeiou':
-                    text = 'valrx' + text
-                    options.trim = 5
-                else:
-                    if text[0] == 'r':
-                        text = 'valn' + text
-                    else:
-                        text = 'valr' + text
-                    options.trim = 4
+            options.rule = 'cmevla'
+            if text[-1] not in 'bcdfgjklmnprstvxz':
+                options.trim = -1
+                text += 'x'
 
     parser = build_parser(options)
     transformer = build_transformer(options, parser)

--- a/camxes.py
+++ b/camxes.py
@@ -94,7 +94,7 @@ def do_parse(text, options):
             if text[-1] in 'bcdfgjklmnprstvxz':
                 options.rule = 'jbocme'
             else:
-                options.rule = 'fuhivla'
+                options.rule = 'fuhivla_any'
                 if text[0] in 'aeiou':
                     text = 'valrx' + text
                     options.trim = 5

--- a/camxes.py
+++ b/camxes.py
@@ -13,7 +13,7 @@ import parsimonious_ext # expression_nodes
 VERSION = "v0.7"
 
 PARSERS      = [ 'camxes-ilmen' ]
-TRANSFORMERS = [ 'camxes-json', 'camxes-morphology', 'vlatai', 'node-coverage', 'debug', 'raw' ]
+TRANSFORMERS = [ 'camxes-json', 'camxes-morphology', 'vlatai', 'node-coverage', 'debug', 'raw', 'lujvo' ]
 SERIALIZERS  = [ 'json', 'json-pretty', 'json-compact', 'xml' ]
 
 IMPLEMENTATION_RECURSION_LIMIT = {
@@ -122,6 +122,9 @@ def build_transformer(transformer_option, parser):
     elif transformer_option == 'raw':
         from transformers import raw
         return raw.Transformer()
+    elif transformer_option == 'lujvo':
+        from transformers import lujvo
+        return lujvo.Transformer()
     else:
         bad_transformer()
 

--- a/camxes.py
+++ b/camxes.py
@@ -83,17 +83,22 @@ def python_platform():
         return "Jython" if platform.system() == "Java" else "CPython"
 
 def python_version():
-    (major, minor, _) = platform.python_version_tuple()
+    (major, minor, patch) = platform.python_version_tuple()
     return (major * 10) + minor
 
-def run(text, options):
+def do_parse(text, options):
     parser = build_parser(options)
     parsed = parser.parse(text)
     transformer = build_transformer(options.transformer, parser)
-    transformed = transformer.transform(parsed)
+    return transformer.transform(parsed), transformer
+
+def main(text, options):
+    transformed, transformer = do_parse(text, options)
     print serialize(transformed,
                     options.serializer,
                     default_object_serializer(transformer))
+def run(text, options):
+    main(text, options)
 
 def build_parser(options):
     parser_option = options.parser if len(PARSERS) > 1 else "camxes-ilmen"

--- a/camxes.py
+++ b/camxes.py
@@ -92,7 +92,7 @@ def do_parse(text, options):
             options.rule = 'lujvo'
         elif options.transformer == 'syllable':
             if text[-1] in 'bcdfgjklmnprstvxz':
-                options.rule = 'jbocme'
+                options.rule = 'cmevla'
             else:
                 options.rule = 'fuhivla_any'
                 if text[0] in 'aeiou':

--- a/camxes.py
+++ b/camxes.py
@@ -13,7 +13,7 @@ import parsimonious_ext # expression_nodes
 VERSION = "v0.7"
 
 PARSERS      = [ 'camxes-ilmen' ]
-TRANSFORMERS = [ 'camxes-json', 'camxes-morphology', 'vlatai', 'node-coverage', 'debug', 'raw', 'lujvo' ]
+TRANSFORMERS = [ 'camxes-json', 'camxes-morphology', 'vlatai', 'node-coverage', 'debug', 'raw', 'lujvo-break', 'lujvo-expand' ]
 SERIALIZERS  = [ 'json', 'json-pretty', 'json-compact', 'xml' ]
 
 IMPLEMENTATION_RECURSION_LIMIT = {
@@ -127,9 +127,12 @@ def build_transformer(transformer_option, parser):
     elif transformer_option == 'raw':
         from transformers import raw
         return raw.Transformer()
-    elif transformer_option == 'lujvo':
+    elif transformer_option == 'lujvo-break':
         from transformers import lujvo
-        return lujvo.Transformer()
+        return lujvo.Transformer(expand=False)
+    elif transformer_option == 'lujvo-expand':
+        from transformers import lujvo
+        return lujvo.Transformer(expand=True)
     else:
         bad_transformer()
 

--- a/jvocuhadju.py
+++ b/jvocuhadju.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+
+import os, sys
+import lxml.etree as et
+from collections import OrderedDict
+import itertools
+
+from parsimonious.exceptions import ParseError
+
+from structures import jbovlaste_types
+from camxes import configure_platform
+from parsers.camxes_ilmen import Parser
+from transformers.lujvo import Visitor
+
+def memoize(f):
+  memory = {}
+  def g(*args):
+    if args not in memory:
+      memory[args] = f(*args)
+    return memory[args]
+  return g
+
+with open(os.path.join(os.path.dirname(sys.argv[0]), "jvs/en.xml")) as xml:
+  tree = et.parse(xml)
+
+def all_rafsi(word):
+  return map(lambda e: e.text, tree.xpath('//valsi[@word="%s"]/rafsi' % word))
+
+def allowed_pair(pair):
+  return (not all(map(lambda c: parse_as("consonant", c), pair))) or parse_as("cluster", pair)
+
+def parse_as(rule, text):
+  try:
+    Parser(rule).parse(text)
+  except ParseError as e:
+    return False
+  return True
+
+def main(words):
+  rafsi = OrderedDict()
+  for i, word in zip(range(len(words)), words):
+    print word
+    rafsi[word] = all_rafsi(word)
+    if parse_as("gismu", word):
+      if i == len(words)-1:
+        rafsi[word] += [word]
+      else:
+        rafsi[word] += [word[:-1] + "y"]
+    if i == len(words)-1:
+      rafsi[word] = filter(lambda r: r[-1] in 'aeiou', rafsi[word])
+      if len(rafsi[word]) == 0:
+        raise Exception('No terminal rafsi available for %s' % word)
+  
+  print rafsi
+
+  good_lujvo = []
+  for lujvo in itertools.product(*rafsi.values()):
+    s = lujvo[0]
+    for component in lujvo[1:]:
+      if allowed_pair(s[-1] + component[0]):
+        s += component
+      else:
+        s += "y" + component
+    if parse_as("lujvo", s):
+      good_lujvo += [s]
+      print 'good: ', s
+    else:
+      print 'bad:  ', s
+
+  print "\n".join(good_lujvo)
+
+if __name__ == '__main__':
+  configure_platform()
+  main(sys.argv[1:])
+

--- a/jvocuhadju.py
+++ b/jvocuhadju.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python
 
-import os, sys
+import os, sys, re
 import lxml.etree as et
-from collections import OrderedDict
-import itertools
+from collections import OrderedDict, Hashable
+import itertools, functools
 
+from optparse import OptionParser
+from camxes import VERSION
 from parsimonious.exceptions import ParseError
 
 from structures import jbovlaste_types
@@ -13,20 +15,44 @@ from camxes import configure_platform
 from parsers.camxes_ilmen import Parser
 from transformers.vlatai import Visitor
 
-def memoize(f):
-  memory = {}
-  def g(*args):
-    if args not in memory:
-      memory[args] = f(*args)
-    return memory[args]
-  return g
+# from https://wiki.python.org/moin/PythonDecoratorLibrary#Memoize
+class memoize(object):
+   '''Decorator. Caches a function's return value each time it is called.
+   If called later with the same arguments, the cached value is returned
+   (not reevaluated).
+   '''
+   def __init__(self, func):
+      self.func = func
+      self.cache = {}
+   def __call__(self, *args):
+      if not isinstance(args, Hashable):
+         # uncacheable. a list, for instance.
+         # better to not cache than blow up.
+         return self.func(*args)
+      if args in self.cache:
+         return self.cache[args]
+      else:
+         value = self.func(*args)
+         self.cache[args] = value
+         return value
+   def __repr__(self):
+        '''Return the function's docstring.'''
+        return self.func.__doc__
+   def __get__(self, obj, objtype):
+        '''Support instance methods.'''
+        return functools.partial(self.__call__, obj)
 
+
+# load jbovlaste dump
 with open(os.path.join(os.path.dirname(sys.argv[0]), "jvs/en.xml")) as xml:
   tree = et.parse(xml)
 
+# utility functions
+@memoize
 def all_rafsi(word):
   return map(lambda e: e.text, tree.xpath('//valsi[@word="%s"]/rafsi' % word))
 
+@memoize
 def allowed_pair(pair):
   return (not all(map(lambda c: parse_as("consonant", c), pair))) or parse_as("cluster", pair)
 
@@ -38,6 +64,7 @@ def expand_all(visited):
   else:
     return visited
 
+@memoize
 def parse_as(rule, text):
   try:
     visited = Visitor().visit(Parser(rule).parse(text))
@@ -45,10 +72,40 @@ def parse_as(rule, text):
   except ParseError as e:
     return False
 
+def lujvo_score(lujvo):
+    l = len(lujvo)
+    a = lujvo.count("'")
+    h = lujvo.count("y")
+    v = sum(lujvo.count(v) for v in 'aeiou')
+    r = 0
+
+    def mapti(r, p):
+        p = p.replace('V', '[aeiou]')
+        p = p.replace('C', '[bcdfgjklmnprstvxz]')
+        p = '^' + p + '$'
+        return re.match(p, r) is not None
+
+    for rafsi in Visitor().visit(Parser('lujvo').parse(lujvo)).raw_rafsi:
+        if mapti(rafsi, "CVV[rn]"):
+            h += 1
+            r += 8
+        elif mapti(rafsi, "CV'V[rn]"):
+            h += 1
+            r += 6
+        elif mapti(rafsi, 'CVCCV'):   r += 1
+        elif mapti(rafsi, 'CVCCy'):    r += 2
+        elif mapti(rafsi, 'CCVCV'):   r += 3
+        elif mapti(rafsi, 'CCVCy'):    r += 4
+        elif mapti(rafsi, 'CVC'):     r += 5
+        elif mapti(rafsi, "CV'V"):    r += 6
+        elif mapti(rafsi, 'CCV'):     r += 7
+        elif mapti(rafsi, 'CVV'):     r += 8
+
+    return (1000 * l) - (500 * a) + (100 * h) - (10 * r) - v
+
 def main(words):
   rafsi = OrderedDict()
   for i, word in zip(range(len(words)), words):
-    print word
     rafsi[word] = all_rafsi(word)
     if parse_as("gismu", word):
       if i == len(words)-1:
@@ -64,8 +121,6 @@ def main(words):
     if len(rafsi[word]) == 0:
       raise Exception('No terminal rafsi available for %s' % word)
   
-  print rafsi
-
   good_lujvo = []
   for lujvo in itertools.product(*rafsi.values()):
     s = lujvo[0]
@@ -75,14 +130,17 @@ def main(words):
       else:
         s += "y" + component
 
-    print s
     if parse_as("lujvo", s):
       good_lujvo += [s]
 
   print '\n'
-  print "\n".join(good_lujvo)
+  print "\n".join(map(lambda s: '%s\t%d' % s, sorted(zip(good_lujvo, map(lujvo_score, good_lujvo)), key=lambda x: x[1])))
 
 if __name__ == '__main__':
+  usage_fmt = "usage: %prog [ options ] { input }"
+  options = OptionParser(usage=usage_fmt, version="%prog " + VERSION)
+  (params, argv) = options.parse_args()
+
   configure_platform()
-  main(sys.argv[1:])
+  main(argv)
 

--- a/parsers/camxes_ilmen.peg
+++ b/parsers/camxes_ilmen.peg
@@ -1461,12 +1461,6 @@ fuhivla = (
   consonantal_syllable*
   final_syllable
 )
-fuhivla_any = (
-  fuhivla_head_any
-  stressed_syllable_any
-  consonantal_syllable*
-  final_syllable
-)
 
 stressed_extended_rafsi = ( stressed_brivla_rafsi / stressed_fuhivla_rafsi )
 
@@ -1493,10 +1487,8 @@ stressed_fuhivla_rafsi = ( fuhivla_head stressed_syllable &consonant onset y )
 fuhivla_rafsi = ( &unstressed_syllable fuhivla_head &consonant onset y h? )
 
 fuhivla_head = ( !rafsi_string brivla_head )
-fuhivla_head_any = ( !rafsi_string brivla_head_any )
 
 brivla_head = ( !cmavo !slinkuhi !h &onset unstressed_syllable* )
-brivla_head_any = ( !cmavo !slinkuhi !h &onset unstressed_syllable_any* )
 
 slinkuhi = ( consonant rafsi_string )
 
@@ -1606,14 +1598,12 @@ r_hyphen = ( ( r &consonant ) / ( n &r ) )
 final_syllable = ( onset !y !stressed nucleus !cmevla &post_word )
 
 stressed_syllable = ( ( &stressed syllable ) / ( syllable &stress ) )
-stressed_syllable_any = ( ( &stressed any_syllable ) / ( any_syllable &stress ) )
 
 stressed_diphthong = ( ( &stressed diphthong ) / ( diphthong &stress ) )
 
 stressed_vowel = ( ( &stressed vowel ) / ( vowel &stress ) )
 
 unstressed_syllable = ( ( !stressed syllable !stress ) / consonantal_syllable )
-unstressed_syllable_any = ( ( !stressed any_syllable !stress ) / consonantal_syllable )
 
 unstressed_diphthong = ( !stressed diphthong !stress )
 

--- a/parsers/camxes_ilmen.peg
+++ b/parsers/camxes_ilmen.peg
@@ -1384,7 +1384,7 @@ non_bu_zei_cmavo = ( !BU !ZEI cmavo_including_y vlatai_spaces? )
 
 cmavo_including_y = ( Y / CMAVO )
 
-tosmabru = cmavo+ ( gismu / lujvo / fuhivla )
+tosmabru = CMAVO+ ( gismu / lujvo / fuhivla )
 
 # ___ GRAMMAR ___
 

--- a/parsers/camxes_ilmen.peg
+++ b/parsers/camxes_ilmen.peg
@@ -1617,18 +1617,14 @@ any_syllable = ( ( onset nucleus coda? ) / consonantal_syllable )
 
 syllable = ( onset !y nucleus coda? )
 
-consonantal_syllable = (
-  consonant syllabic
-  &( consonantal_syllable / ( !nucleus onset ) )
-  ( consonant &spaces )?
-)
+consonantal_syllable = ( consonant &syllabic coda )
 
 coda = (
   ( !any_syllable consonant &any_syllable )
   / ( syllabic? consonant? &pause )
 )
 
-onset = ( h / ( consonant? glide ) / initial )
+onset = ( h / glide / initial )
 
 nucleus = ( vowel / diphthong / ( y !nucleus ) )
 
@@ -1676,39 +1672,39 @@ voiced = ( b / d / g / j / v / z )
 
 unvoiced = ( c / f / k / p / s / t / x )
 
-l = ( comma* ~"[lL]" !h !l )
+l = ( comma* ~"[lL]" !h !glide !l )
 
-m = ( comma* ~"[mM]" !h !m !z )
+m = ( comma* ~"[mM]" !h !glide !m !z )
 
-n = ( comma* ~"[nN]" !h !n !affricate )
+n = ( comma* ~"[nN]" !h !glide !n !affricate )
 
-r = ( comma* ~"[rR]" !h !r )
+r = ( comma* ~"[rR]" !h !glide !r )
 
-b = ( comma* ~"[bB]" !h !b !unvoiced )
+b = ( comma* ~"[bB]" !h !glide !b !unvoiced )
 
-d = ( comma* ~"[dD]" !h !d !unvoiced )
+d = ( comma* ~"[dD]" !h !glide !d !unvoiced )
 
-g = ( comma* ~"[gG]" !h !g !unvoiced )
+g = ( comma* ~"[gG]" !h !glide !g !unvoiced )
 
-v = ( comma* ~"[vV]" !h !v !unvoiced )
+v = ( comma* ~"[vV]" !h !glide !v !unvoiced )
 
-j = ( comma* ~"[jJ]" !h !j !z !unvoiced )
+j = ( comma* ~"[jJ]" !h !glide !j !z !unvoiced )
 
-z = ( comma* ~"[zZ]" !h !z !j !unvoiced )
+z = ( comma* ~"[zZ]" !h !glide !z !j !unvoiced )
 
-s = ( comma* ~"[sS]" !h !s !c !voiced )
+s = ( comma* ~"[sS]" !h !glide !s !c !voiced )
 
-c = ( comma* ~"[cC]" !h !c !s !x !voiced )
+c = ( comma* ~"[cC]" !h !glide !c !s !x !voiced )
 
-x = ( comma* ~"[xX]" !h !x !c !k !voiced )
+x = ( comma* ~"[xX]" !h !glide !x !c !k !voiced )
 
-k = ( comma* ~"[kK]" !h !k !x !voiced )
+k = ( comma* ~"[kK]" !h !glide !k !x !voiced )
 
-f = ( comma* ~"[fF]" !h !f !voiced )
+f = ( comma* ~"[fF]" !h !glide !f !voiced )
 
-p = ( comma* ~"[pP]" !h !p !voiced )
+p = ( comma* ~"[pP]" !h !glide !p !voiced )
 
-t = ( comma* ~"[tT]" !h !t !voiced )
+t = ( comma* ~"[tT]" !h !glide !t !voiced )
 
 h = ( comma* ~"['h]" &nucleus )
 

--- a/parsers/camxes_ilmen.peg
+++ b/parsers/camxes_ilmen.peg
@@ -1345,7 +1345,7 @@ vlatai = (
     / ZEI
     / vlatai_bu_clause
     / vlatai_zei_clause
-    / CMEVLA
+    / jbocme / zifcme
     / fuhivla
     / BRIVLA
     / tosmabru / slinkuhi

--- a/parsers/camxes_ilmen.peg
+++ b/parsers/camxes_ilmen.peg
@@ -1340,17 +1340,16 @@ CMAVO = (
 
 vlatai = (
   vlatai_spaces?
-  (
+  ( 
     BU
     / ZEI
     / vlatai_bu_clause
     / vlatai_zei_clause
-    / tosmabru
+    / CMEVLA
+    / tosmabru / slinkuhi_no_recurse
     / ( non_bu_zei_cmavo+ )
     / fuhivla
     / BRIVLA
-    / CMEVLA
-    / slinkuhi
   )
   vlatai_spaces?
 )
@@ -1500,7 +1499,7 @@ brivla_head = ( !cmavo !slinkuhi !h &onset unstressed_syllable* )
 brivla_head_any = ( !cmavo !slinkuhi !h &onset unstressed_syllable_any* )
 
 slinkuhi = ( consonant rafsi_string )
-slinkuhi_no_recurse = ( !cmevla !lujvo ( consonant rafsi_string ) )
+slinkuhi_no_recurse = ( !lujvo ( consonant rafsi_string ) )
 
 rafsi_string = (
   y_less_rafsi*

--- a/parsers/camxes_ilmen.peg
+++ b/parsers/camxes_ilmen.peg
@@ -39,6 +39,8 @@ text = (
   EOF?
 )
 
+word_sequence = any_word+
+
 intro_null = ( spaces? su_clause* intro_si_clause )
 
 text_part_2 = ( ( CMEVLA_clause+ / indicators? ) free* )
@@ -1652,9 +1654,7 @@ syllable = ( onset !y nucleus coda? )
 
 consonantal_syllable = (
   consonant syllabic
-  &( consonantal_syllable / onset )
-  ( consonant &spaces )?
-  !nucleus
+  &( consonantal_syllable / ( !nucleus onset ) )
   ( consonant &spaces )?
 )
 

--- a/parsers/camxes_ilmen.peg
+++ b/parsers/camxes_ilmen.peg
@@ -1523,7 +1523,8 @@ fuhivla_head_any = ( !rafsi_string brivla_head_any )
 brivla_head = ( !cmavo !slinkuhi !h &onset unstressed_syllable* )
 brivla_head_any = ( !cmavo !slinkuhi !h &onset unstressed_syllable_any* )
 
-slinkuhi = ( !rafsi_string consonant rafsi_string )
+slinkuhi = ( consonant rafsi_string )
+slinkuhi_no_recurse = ( !cmevla !lujvo ( consonant rafsi_string ) )
 
 rafsi_string = (
   y_less_rafsi*

--- a/parsers/camxes_ilmen.peg
+++ b/parsers/camxes_ilmen.peg
@@ -1484,6 +1484,12 @@ fuhivla = (
   consonantal_syllable*
   final_syllable
 )
+fuhivla_any = (
+  fuhivla_head_any
+  stressed_syllable_any
+  consonantal_syllable*
+  final_syllable
+)
 
 stressed_extended_rafsi = ( stressed_brivla_rafsi / stressed_fuhivla_rafsi )
 
@@ -1510,8 +1516,10 @@ stressed_fuhivla_rafsi = ( fuhivla_head stressed_syllable &consonant onset y )
 fuhivla_rafsi = ( &unstressed_syllable fuhivla_head &consonant onset y h? )
 
 fuhivla_head = ( !rafsi_string brivla_head )
+fuhivla_head_any = ( !rafsi_string brivla_head_any )
 
 brivla_head = ( !cmavo !slinkuhi !h &onset unstressed_syllable* )
+brivla_head_any = ( !cmavo !slinkuhi !h &onset unstressed_syllable_any* )
 
 slinkuhi = ( !rafsi_string consonant rafsi_string )
 
@@ -1621,12 +1629,14 @@ r_hyphen = ( ( r &consonant ) / ( n &r ) )
 final_syllable = ( onset !y !stressed nucleus !cmevla &post_word )
 
 stressed_syllable = ( ( &stressed syllable ) / ( syllable &stress ) )
+stressed_syllable_any = ( ( &stressed any_syllable ) / ( any_syllable &stress ) )
 
 stressed_diphthong = ( ( &stressed diphthong ) / ( diphthong &stress ) )
 
 stressed_vowel = ( ( &stressed vowel ) / ( vowel &stress ) )
 
 unstressed_syllable = ( ( !stressed syllable !stress ) / consonantal_syllable )
+unstressed_syllable_any = ( ( !stressed any_syllable !stress ) / consonantal_syllable )
 
 unstressed_diphthong = ( !stressed diphthong !stress )
 
@@ -1642,6 +1652,8 @@ syllable = ( onset !y nucleus coda? )
 
 consonantal_syllable = (
   consonant syllabic
+  &( consonantal_syllable / onset )
+  ( consonant &spaces )?
   !nucleus
   ( consonant &spaces )?
 )

--- a/parsers/camxes_ilmen.peg
+++ b/parsers/camxes_ilmen.peg
@@ -1385,24 +1385,29 @@ cmavo_including_y = ( Y / CMAVO )
 
 tosmabru = cmavo+ ( gismu / lujvo / fuhivla )
 
-vlatai_type3_fuhivla = ( &fuhivla
-                         ( ( ( CVC_rafsi / stressed_CVC_rafsi )
-                             r_hyphen
-                             syllable+
-                           )
-                           /
-                           ( ( long_rafsi / stressed_long_rafsi )
-                             r_hyphen
-                             syllable+
-                           )
-                         )
-                       )
+vlatai_fuhivla_hyphen = r / n / l
+vlatai_type3_fuhivla  = ( &fuhivla
+                          ( ( ( CVC_rafsi / stressed_CVC_rafsi )
+                              vlatai_fuhivla_hyphen
+                              syllable+
+                            )
+                            /
+                            ( ( long_rafsi / stressed_long_rafsi )
+                              vlatai_fuhivla_hyphen
+                              syllable+
+                            )
+                          )
+                        )
+vlatai_type35_fuhivla = ( &fuhivla
+                          ( ( CCV_rafsi / stressed_CCV_rafsi )
+                            vlatai_fuhivla_hyphen
+                            syllable+
+                          )
+                        )
 
 vlatai_type4_fuhivla = !vlatai_type3_fuhivla fuhivla
 
-vlatai_type35_fuhivla = &( CCV_rafsi / stressed_CCV_rafsi ) vlatai_type4_fuhivla
-
-vlatai_fuhivla = vlatai_type3_fuhivla / vlatai_type4_fuhivla / vlatai_type35_fuhivla
+vlatai_fuhivla = vlatai_type3_fuhivla / vlatai_type35_fuhivla / vlatai_type4_fuhivla
 
 # ___ GRAMMAR ___
 

--- a/parsers/camxes_ilmen.peg
+++ b/parsers/camxes_ilmen.peg
@@ -1347,7 +1347,7 @@ vlatai = (
     / vlatai_zei_clause
     / tosmabru
     / ( non_bu_zei_cmavo+ )
-    / vlatai_fuhivla
+    / fuhivla
     / BRIVLA
     / CMEVLA
     / slinkuhi
@@ -1386,33 +1386,6 @@ non_bu_zei_cmavo = ( !BU !ZEI cmavo_including_y vlatai_spaces? )
 cmavo_including_y = ( Y / CMAVO )
 
 tosmabru = cmavo+ ( gismu / lujvo / fuhivla )
-
-vlatai_fuhivla_hyphen = ( ( !r consonant r !r)
-                        / ( n n !n ) / ( !n consonant n &n )
-                        / ( l l !l ) / ( !l consonant l &l )
-                        )
-vlatai_type3_fuhivla  = ( &fuhivla
-                          ( ( ( long_rafsi / stressed_long_rafsi )
-                              vlatai_fuhivla_hyphen
-                              syllable+
-                            )
-                            /
-                            ( ( CVC_rafsi / stressed_CVC_rafsi )
-                              vlatai_fuhivla_hyphen
-                              syllable+
-                            )
-                          )
-                        )
-vlatai_type35_fuhivla = ( &fuhivla
-                          ( ( CCV_rafsi / stressed_CCV_rafsi )
-                            vlatai_fuhivla_hyphen
-                            syllable+
-                          )
-                        )
-
-vlatai_type4_fuhivla = ( !vlatai_type3_fuhivla fuhivla )
-
-vlatai_fuhivla = ( vlatai_type3_fuhivla / vlatai_type35_fuhivla / vlatai_type4_fuhivla )
 
 # ___ GRAMMAR ___
 

--- a/parsers/camxes_ilmen.peg
+++ b/parsers/camxes_ilmen.peg
@@ -1642,7 +1642,7 @@ syllable = ( onset !y nucleus coda? )
 
 consonantal_syllable = (
   consonant syllabic
-  &( consonantal_syllable / onset )
+  !nucleus
   ( consonant &spaces )?
 )
 

--- a/parsers/camxes_ilmen.peg
+++ b/parsers/camxes_ilmen.peg
@@ -1387,14 +1387,17 @@ cmavo_including_y = ( Y / CMAVO )
 
 tosmabru = cmavo+ ( gismu / lujvo / fuhivla )
 
-vlatai_fuhivla_hyphen = r / n / l
+vlatai_fuhivla_hyphen = ( ( !r consonant r !r)
+                        / ( n n !n ) / ( !n consonant n &n )
+                        / ( l l !l ) / ( !l consonant l &l )
+                        )
 vlatai_type3_fuhivla  = ( &fuhivla
-                          ( ( ( CVC_rafsi / stressed_CVC_rafsi )
+                          ( ( ( long_rafsi / stressed_long_rafsi )
                               vlatai_fuhivla_hyphen
                               syllable+
                             )
                             /
-                            ( ( long_rafsi / stressed_long_rafsi )
+                            ( ( CVC_rafsi / stressed_CVC_rafsi )
                               vlatai_fuhivla_hyphen
                               syllable+
                             )
@@ -1407,9 +1410,9 @@ vlatai_type35_fuhivla = ( &fuhivla
                           )
                         )
 
-vlatai_type4_fuhivla = !vlatai_type3_fuhivla fuhivla
+vlatai_type4_fuhivla = ( !vlatai_type3_fuhivla fuhivla )
 
-vlatai_fuhivla = vlatai_type3_fuhivla / vlatai_type35_fuhivla / vlatai_type4_fuhivla
+vlatai_fuhivla = ( vlatai_type3_fuhivla / vlatai_type35_fuhivla / vlatai_type4_fuhivla )
 
 # ___ GRAMMAR ___
 

--- a/parsers/camxes_ilmen.peg
+++ b/parsers/camxes_ilmen.peg
@@ -1345,6 +1345,7 @@ vlatai = (
     / vlatai_zei_clause
     / tosmabru
     / ( non_bu_zei_cmavo+ )
+    / vlatai_fuhivla
     / BRIVLA
     / CMEVLA
     / slinkuhi
@@ -1383,6 +1384,25 @@ non_bu_zei_cmavo = ( !BU !ZEI cmavo_including_y vlatai_spaces? )
 cmavo_including_y = ( Y / CMAVO )
 
 tosmabru = cmavo+ ( gismu / lujvo / fuhivla )
+
+vlatai_type3_fuhivla = ( &fuhivla
+                         ( ( ( CVC_rafsi / stressed_CVC_rafsi )
+                             r_hyphen
+                             syllable+
+                           )
+                           /
+                           ( ( long_rafsi / stressed_long_rafsi )
+                             r_hyphen
+                             syllable+
+                           )
+                         )
+                       )
+
+vlatai_type4_fuhivla = !vlatai_type3_fuhivla fuhivla
+
+vlatai_type35_fuhivla = &( CCV_rafsi / stressed_CCV_rafsi ) vlatai_type4_fuhivla
+
+vlatai_fuhivla = vlatai_type3_fuhivla / vlatai_type4_fuhivla / vlatai_type35_fuhivla
 
 # ___ GRAMMAR ___
 

--- a/parsers/camxes_ilmen.peg
+++ b/parsers/camxes_ilmen.peg
@@ -1346,10 +1346,10 @@ vlatai = (
     / vlatai_bu_clause
     / vlatai_zei_clause
     / CMEVLA
-    / tosmabru / slinkuhi_no_recurse
-    / ( non_bu_zei_cmavo+ )
     / fuhivla
     / BRIVLA
+    / tosmabru / slinkuhi
+    / ( non_bu_zei_cmavo+ )
   )
   vlatai_spaces?
 )
@@ -1499,7 +1499,6 @@ brivla_head = ( !cmavo !slinkuhi !h &onset unstressed_syllable* )
 brivla_head_any = ( !cmavo !slinkuhi !h &onset unstressed_syllable_any* )
 
 slinkuhi = ( consonant rafsi_string )
-slinkuhi_no_recurse = ( !lujvo ( consonant rafsi_string ) )
 
 rafsi_string = (
   y_less_rafsi*

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,32 @@
+
+
+import os
+from setuptools import setup
+
+# Utility function to read the README file.
+# Used for the long_description.  It's nice, because now 1) we have a top level
+# README file and 2) it's easier to type in the README file than to put a raw
+# string in below ...
+def read(fname):
+    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+
+setup(
+    name = "camxes",
+    version = "0.6",
+    author = "Riley Martinez-Lynch",
+    author_email = "camxes@alexburka.com",
+    description = ("PEG parser and associated tools for Lojban"),
+    license = "MIT",
+    keywords = "lojban parser peg",
+    url = "http://github.com/teleological/camxes-py",
+    py_modules=['camxes'],
+    long_description=read('README.txt'),
+    classifiers=[
+        "Development Status :: 3 - Alpha",
+        "Topic :: Utilities",
+        "License :: OSI Approved :: MIT License",
+    ],
+)
+
+
+

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         "Topic :: Utilities",
         "License :: OSI Approved :: MIT License",
     ],
-    install_requires=['parsimonious']
+    install_requires=['parsimonious', 'lxml']
 )
 
 

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
         "Topic :: Utilities",
         "License :: OSI Approved :: MIT License",
     ],
+    install_requires=['parsimonious']
 )
 
 

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     keywords = "lojban parser peg",
     url = "http://github.com/teleological/camxes-py",
     py_modules=['camxes'],
+    data_files=[('jvs', ['jvs/en.xml'])],
     long_description=read('README.txt'),
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/structures/gensuha.py
+++ b/structures/gensuha.py
@@ -91,6 +91,14 @@ class Fuhivla(Brivla):
 
     GENTURTAI = "fuhivla"
 
+class Fuhivla3(Brivla):
+
+  GENTURTAI = "type-3 fuhivla"
+
+class Fuhivla4(Brivla):
+
+  GENTURTAI = "type-4 fuhivla"
+
 class Cmavo(Valsi):
 
     GENTURTAI = "cmavo"

--- a/structures/gensuha.py
+++ b/structures/gensuha.py
@@ -87,63 +87,86 @@ class Lujvo(Brivla, Jvodunlei):
 
     GENTURTAI = "lujvo"
 
+    def __init__(self, lerpoi, rafsi):
+        self.lerpoi = lerpoi
+        self.raw_rafsi = rafsi
+        self.rafsi = []
+        for r in rafsi:
+            if r[-1] == 'y':
+                if r[-2] == "'":
+                    self.rafsi.append(r[:-2]) # extended rafsi
+                else:
+                    self.rafsi.append(r[:-1]) # normal rafsi plus 'y'
+            elif r[-2:] == "y'":
+                self.rafsi.append(r[:-2]) # extended rafsi
+            elif (len(r) in [4, 5]) and (r[-1] in ['r', 'n']):
+                self.rafsi.append(r[:-1]) # normal rafsi plus hyphen
+            else:
+                self.rafsi.append(r) # normal rafsi
+
+    def as_json(self):
+        return OrderedDict([
+            ( "genturtai", self.GENTURTAI ),
+            ( "rafsi",         self.rafsi         )
+        ])
+
 class Fuhivla(Brivla):
 
     GENTURTAI = "fuhivla"
 
 class Fuhivla3(Fuhivla):
 
-  GENTURTAI = "fuhivla"
+    GENTURTAI = "fuhivla"
 
-  def __init__(self, lerpoi, rafsi, hyphen, payload):
-    self.lerpoi = lerpoi
-    self.type = "3"
-    self.rafsi = rafsi
-    self.hyphen = hyphen
-    self.payload = payload
+    def __init__(self, lerpoi, rafsi, hyphen, payload):
+        self.lerpoi = lerpoi
+        self.type = "3"
+        self.rafsi = rafsi
+        self.hyphen = hyphen
+        self.payload = payload
 
-  def as_json(self):
-    return OrderedDict([
-      ( "genturtai", self.GENTURTAI ),
-      ( "type",      self.type      ),
-      ( "rafsi",     self.rafsi     ),
-      ( "hyphen",    self.hyphen    ),
-      ( "payload",   self.payload   )
-    ])
+    def as_json(self):
+        return OrderedDict([
+            ( "genturtai", self.GENTURTAI ),
+            ( "type",            self.type            ),
+            ( "rafsi",         self.rafsi         ),
+            ( "hyphen",        self.hyphen        ),
+            ( "payload",     self.payload     )
+        ])
 
 class Fuhivla35(Fuhivla3):
 
-  GENTURTAI = "fuhivla"
+    GENTURTAI = "fuhivla"
 
-  def __init__(self, lerpoi, rafsi, hyphen, payload):
-    self.lerpoi = lerpoi
-    self.type = "3.5"
-    self.rafsi = rafsi
-    self.hyphen = hyphen
-    self.payload = payload
+    def __init__(self, lerpoi, rafsi, hyphen, payload):
+        self.lerpoi = lerpoi
+        self.type = "3.5"
+        self.rafsi = rafsi
+        self.hyphen = hyphen
+        self.payload = payload
 
-  def as_json(self):
-    return OrderedDict([
-      ( "genturtai", self.GENTURTAI ),
-      ( "type",      self.type      ),
-      ( "rafsi",     self.rafsi     ),
-      ( "hyphen",    self.hyphen    ),
-      ( "payload",   self.payload   )
-    ])
+    def as_json(self):
+        return OrderedDict([
+            ( "genturtai", self.GENTURTAI ),
+            ( "type",            self.type            ),
+            ( "rafsi",         self.rafsi         ),
+            ( "hyphen",        self.hyphen        ),
+            ( "payload",     self.payload     )
+        ])
 
 class Fuhivla4(Fuhivla):
 
-  GENTURTAI = "fuhivla"
+    GENTURTAI = "fuhivla"
 
-  def __init__(self, lerpoi):
-    self.lerpoi = lerpoi
-    self.type = "4"
+    def __init__(self, lerpoi):
+        self.lerpoi = lerpoi
+        self.type = "4"
 
-  def as_json(self):
-    return OrderedDict([
-      ( "genturtai", self.GENTURTAI ),
-      ( "type",      self.type      )
-    ])
+    def as_json(self):
+        return OrderedDict([
+            ( "genturtai", self.GENTURTAI ),
+            ( "type",            self.type            )
+        ])
 
 class Cmavo(Valsi):
 

--- a/structures/gensuha.py
+++ b/structures/gensuha.py
@@ -71,7 +71,16 @@ class Cmevla(Valsi):
     GENTURTAI = "cmevla"
 
 class Selbri(object): # not itself a structure, but a property of some structures
-    pass
+  def __init__(self, lerpoi, cmekle):
+    self.lerpoi = lerpoi
+    self.klesi = cmekle
+
+  def as_json(self):
+    return OrderedDict([
+      ( "genturtai", self.GENTURTAI ),
+      ( "lerpoi",    self.lerpoi    ),
+      ( "klesi",     self.klesi     )
+    ])
 
 class Brivla(Valsi, Selbri):
     pass

--- a/structures/gensuha.py
+++ b/structures/gensuha.py
@@ -93,11 +93,11 @@ class Lujvo(Brivla, Jvodunlei):
         self.rafsi = []
         for r in rafsi:
             if r[-1] == 'y':
-                if r[-2] == "'":
+                if r[-2] in "'h":
                     self.rafsi.append(r[:-2]) # extended rafsi
                 else:
                     self.rafsi.append(r[:-1]) # normal rafsi plus 'y'
-            elif r[-2:] == "y'":
+            elif r[-2:] in ["y'", "yh"]:
                 self.rafsi.append(r[:-2]) # extended rafsi
             elif (len(r) in [4, 5]) and (r[-1] in ['r', 'n']):
                 self.rafsi.append(r[:-1]) # normal rafsi plus hyphen

--- a/structures/gensuha.py
+++ b/structures/gensuha.py
@@ -95,6 +95,10 @@ class Fuhivla3(Brivla):
 
   GENTURTAI = "type-3 fuhivla"
 
+class Fuhivla35(Brivla):
+
+  GENTURTAI = "type-3.5 fuhivla"
+
 class Fuhivla4(Brivla):
 
   GENTURTAI = "type-4 fuhivla"

--- a/structures/gensuha.py
+++ b/structures/gensuha.py
@@ -70,17 +70,19 @@ class Cmevla(Valsi):
 
     GENTURTAI = "cmevla"
 
-class Selbri(object): # not itself a structure, but a property of some structures
-  def __init__(self, lerpoi, cmekle):
-    self.lerpoi = lerpoi
-    self.klesi = cmekle
+    def __init__(self, lerpoi, cmekle):
+        self.lerpoi = lerpoi
+        self.klesi = cmekle
+    
+    def as_json(self):
+        return OrderedDict([
+            ( "genturtai", self.GENTURTAI ),
+            ( "lerpoi",    self.lerpoi    ),
+            ( "klesi",     self.klesi     )
+        ])
 
-  def as_json(self):
-    return OrderedDict([
-      ( "genturtai", self.GENTURTAI ),
-      ( "lerpoi",    self.lerpoi    ),
-      ( "klesi",     self.klesi     )
-    ])
+class Selbri(object): # not itself a structure, but a property of some structures
+    pass
 
 class Brivla(Valsi, Selbri):
     pass

--- a/structures/gensuha.py
+++ b/structures/gensuha.py
@@ -91,17 +91,59 @@ class Fuhivla(Brivla):
 
     GENTURTAI = "fuhivla"
 
-class Fuhivla3(Brivla):
+class Fuhivla3(Fuhivla):
 
-  GENTURTAI = "type-3 fuhivla"
+  GENTURTAI = "fuhivla"
 
-class Fuhivla35(Brivla):
+  def __init__(self, lerpoi, rafsi, hyphen, payload):
+    self.lerpoi = lerpoi
+    self.type = "3"
+    self.rafsi = rafsi
+    self.hyphen = hyphen
+    self.payload = payload
 
-  GENTURTAI = "type-3.5 fuhivla"
+  def as_json(self):
+    return OrderedDict([
+      ( "genturtai", self.GENTURTAI ),
+      ( "type",      self.type      ),
+      ( "rafsi",     self.rafsi     ),
+      ( "hyphen",    self.hyphen    ),
+      ( "payload",   self.payload   )
+    ])
 
-class Fuhivla4(Brivla):
+class Fuhivla35(Fuhivla3):
 
-  GENTURTAI = "type-4 fuhivla"
+  GENTURTAI = "fuhivla"
+
+  def __init__(self, lerpoi, rafsi, hyphen, payload):
+    self.lerpoi = lerpoi
+    self.type = "3.5"
+    self.rafsi = rafsi
+    self.hyphen = hyphen
+    self.payload = payload
+
+  def as_json(self):
+    return OrderedDict([
+      ( "genturtai", self.GENTURTAI ),
+      ( "type",      self.type      ),
+      ( "rafsi",     self.rafsi     ),
+      ( "hyphen",    self.hyphen    ),
+      ( "payload",   self.payload   )
+    ])
+
+class Fuhivla4(Fuhivla):
+
+  GENTURTAI = "fuhivla"
+
+  def __init__(self, lerpoi):
+    self.lerpoi = lerpoi
+    self.type = "4"
+
+  def as_json(self):
+    return OrderedDict([
+      ( "genturtai", self.GENTURTAI ),
+      ( "type",      self.type      )
+    ])
 
 class Cmavo(Valsi):
 

--- a/structures/gensuha.py
+++ b/structures/gensuha.py
@@ -106,8 +106,8 @@ class Lujvo(Brivla, Jvodunlei):
 
     def as_json(self):
         return OrderedDict([
-            ( "genturtai", self.GENTURTAI ),
-            ( "rafsi",         self.rafsi         )
+            ( "genturtai", self.GENTURTAI),
+            ( "rafsi",         self.rafsi)
         ])
 
 class Fuhivla(Brivla):
@@ -118,40 +118,36 @@ class Fuhivla3(Fuhivla):
 
     GENTURTAI = "fuhivla"
 
-    def __init__(self, lerpoi, rafsi, hyphen, payload):
+    def __init__(self, lerpoi, rafsi, payload):
         self.lerpoi = lerpoi
         self.type = "3"
         self.rafsi = rafsi
-        self.hyphen = hyphen
         self.payload = payload
 
     def as_json(self):
         return OrderedDict([
             ( "genturtai", self.GENTURTAI ),
-            ( "type",            self.type            ),
-            ( "rafsi",         self.rafsi         ),
-            ( "hyphen",        self.hyphen        ),
-            ( "payload",     self.payload     )
+            ( "type",            self.type),
+            ( "rafsi",         self.rafsi ),
+            ( "payload",     self.payload )
         ])
 
 class Fuhivla35(Fuhivla3):
 
     GENTURTAI = "fuhivla"
 
-    def __init__(self, lerpoi, rafsi, hyphen, payload):
+    def __init__(self, lerpoi, rafsi, payload):
         self.lerpoi = lerpoi
         self.type = "3.5"
         self.rafsi = rafsi
-        self.hyphen = hyphen
         self.payload = payload
 
     def as_json(self):
         return OrderedDict([
             ( "genturtai", self.GENTURTAI ),
-            ( "type",            self.type            ),
-            ( "rafsi",         self.rafsi         ),
-            ( "hyphen",        self.hyphen        ),
-            ( "payload",     self.payload     )
+            ( "type",            self.type),
+            ( "rafsi",         self.rafsi ),
+            ( "payload",     self.payload )
         ])
 
 class Fuhivla4(Fuhivla):
@@ -165,7 +161,7 @@ class Fuhivla4(Fuhivla):
     def as_json(self):
         return OrderedDict([
             ( "genturtai", self.GENTURTAI ),
-            ( "type",            self.type            )
+            ( "type",            self.type)
         ])
 
 class Cmavo(Valsi):

--- a/structures/jbovlaste_types.py
+++ b/structures/jbovlaste_types.py
@@ -32,7 +32,10 @@ def classify(gensuha, simple=False):
 
 def classify_gensuha(gensuha, simple=False):
   if isinstance(gensuha, Cmevla):
-    return CMEVLA
+    if simple:
+      return CMEVLA
+    else:
+      return '%s/%s' % (CMEVLA, gensuha.klesi)
   elif isinstance(gensuha, Gismu):
     return GISMU
   elif isinstance(gensuha, Lujvo):

--- a/structures/jbovlaste_types.py
+++ b/structures/jbovlaste_types.py
@@ -50,7 +50,10 @@ def classify_gensuha(gensuha, simple=False):
       return CMAVO
     return '%s/%s' % (CMAVO, gensuha.selmaho)
   elif isinstance(gensuha, ZeiLujvo):
-    return ZEI_LUJVO
+    if simple:
+      return ZEI_LUJVO
+    else:
+      return '%s (%s)' % (ZEI_LUJVO, classify_gensuha_sequence(filter(lambda v: v.lerpoi != 'zei', gensuha.vlapoi)))
   elif isinstance(gensuha, BuLetteral):
     return BU_LETTERAL
   elif isinstance(gensuha, Tosmabru):

--- a/structures/jbovlaste_types.py
+++ b/structures/jbovlaste_types.py
@@ -2,7 +2,7 @@
 # pylint: disable=I0011, C0111, C0326
 
 from structures.gensuha \
-  import Cmevla, Gismu, Lujvo, Fuhivla, Cmavo, ZeiLujvo, BuLetteral, Tosmabru, Slinkuhi
+  import Cmevla, Gismu, Lujvo, Fuhivla, Fuhivla3, Fuhivla4, Cmavo, ZeiLujvo, BuLetteral, Tosmabru, Slinkuhi
 
 # legacy classifications
 CMEVLA        = "cmevla"
@@ -20,6 +20,8 @@ ZEI_LUJVO      = "zei-lujvo"
 # non-jvs types
 TOSMABRU       = "valrtosmabru"
 SLINKUHI       = "valslinku'i"
+FUHIVLA3       = "type-3 fu'ivla"
+FUHIVLA4       = "type-4 fu'ivla"
 
 def classify(gensuha):
     if gensuha is None or len(gensuha) < 1:
@@ -39,6 +41,10 @@ def classify_gensuha(gensuha):
         classified = LUJVO
     elif isinstance(gensuha, Fuhivla):
         classified = FUHIVLA
+    elif isinstance(gensuha, Fuhivla3):
+        classified = FUHIVLA3
+    elif isinstance(gensuha, Fuhivla4):
+        classified = FUHIVLA4
     elif isinstance(gensuha, Cmavo):
         classified = CMAVO
     elif isinstance(gensuha, ZeiLujvo):

--- a/structures/jbovlaste_types.py
+++ b/structures/jbovlaste_types.py
@@ -43,7 +43,7 @@ def classify_gensuha(gensuha, simple=False):
     if simple:
       return FUHIVLA
     if isinstance(gensuha, Fuhivla3):
-      return '%s/%s/%s-%s-%s' % (FUHIVLA, gensuha.type, gensuha.rafsi, gensuha.hyphen, gensuha.payload)
+      return '%s/%s/%s-%s' % (FUHIVLA, gensuha.type, gensuha.rafsi, gensuha.payload)
     return '%s/%s' % (FUHIVLA, gensuha.type)
   elif isinstance(gensuha, Cmavo):
     if simple:

--- a/structures/jbovlaste_types.py
+++ b/structures/jbovlaste_types.py
@@ -34,40 +34,35 @@ def classify(gensuha):
         return classify_gensuha_sequence(gensuha)
 
 def classify_gensuha(gensuha):
-    classified = None
-    if isinstance(gensuha, Cmevla):
-        classified = CMEVLA
-    elif isinstance(gensuha, Gismu):
-        classified = GISMU
-    elif isinstance(gensuha, Lujvo):
-        classified = LUJVO
-    elif isinstance(gensuha, Fuhivla):
-        classified = FUHIVLA
-    elif isinstance(gensuha, Fuhivla3):
-        classified = FUHIVLA3
-    elif isinstance(gensuha, Fuhivla35):
-        classified = FUHIVLA35
-    elif isinstance(gensuha, Fuhivla4):
-        classified = FUHIVLA4
-    elif isinstance(gensuha, Cmavo):
-        classified = CMAVO
-    elif isinstance(gensuha, ZeiLujvo):
-        classified = ZEI_LUJVO
-    elif isinstance(gensuha, BuLetteral):
-        classified = BU_LETTERAL
-    elif isinstance(gensuha, Tosmabru):
-        classified = TOSMABRU
-    elif isinstance(gensuha, Slinkuhi):
-        classified = SLINKUHI
+  if isinstance(gensuha, Cmevla):
+    return CMEVLA
+  elif isinstance(gensuha, Gismu):
+    return GISMU
+  elif isinstance(gensuha, Lujvo):
+    return LUJVO
+  elif isinstance(gensuha, Fuhivla):
+    if isinstance(gensuha, Fuhivla3):
+      return '%s/%s/%s-%s-%s' % (FUHIVLA, gensuha.type, gensuha.rafsi, gensuha.hyphen, gensuha.payload)
     else:
-        classified = NALVLA
-    return classified
+      return '%s/%s' % (FUHIVLA, gensuha.type)
+  elif isinstance(gensuha, Cmavo):
+    return '%s/%s' % (CMAVO, gensuha.selmaho)
+  elif isinstance(gensuha, ZeiLujvo):
+    return ZEI_LUJVO
+  elif isinstance(gensuha, BuLetteral):
+    return BU_LETTERAL
+  elif isinstance(gensuha, Tosmabru):
+    return TOSMABRU
+  elif isinstance(gensuha, Slinkuhi):
+    return SLINKUHI
+  else:
+    return NALVLA
 
 def classify_gensuha_sequence(gensuha):
-    if is_cmavo_sequence(gensuha):
-        return CMAVO_COMPOUND
-    else:
-        return NALVLA
+  if is_cmavo_sequence(gensuha):
+    return ' '.join(map(classify_gensuha, gensuha))
+  else:
+    return NALVLA
 
 def is_cmavo_sequence(gensuha):
     return all(isinstance(g, Cmavo) for g in gensuha)

--- a/structures/jbovlaste_types.py
+++ b/structures/jbovlaste_types.py
@@ -25,15 +25,15 @@ FUHIVLA3       = "type-3 fu'ivla"
 FUHIVLA35      = "type-3.5 fu'ivla"
 FUHIVLA4       = "type-4 fu'ivla"
 
-def classify(gensuha):
+def classify(gensuha, simple=False):
     if gensuha is None or len(gensuha) < 1:
         return NALVLA
     elif len(gensuha) == 1:
-        return classify_gensuha(gensuha[0])
+        return classify_gensuha(gensuha[0], simple)
     else:
-        return classify_gensuha_sequence(gensuha)
+        return classify_gensuha_sequence(gensuha, simple)
 
-def classify_gensuha(gensuha):
+def classify_gensuha(gensuha, simple=False):
   if isinstance(gensuha, Cmevla):
     return CMEVLA
   elif isinstance(gensuha, Gismu):
@@ -41,11 +41,14 @@ def classify_gensuha(gensuha):
   elif isinstance(gensuha, Lujvo):
     return LUJVO
   elif isinstance(gensuha, Fuhivla):
+    if simple:
+      return FUHIVLA
     if isinstance(gensuha, Fuhivla3):
       return '%s/%s/%s-%s-%s' % (FUHIVLA, gensuha.type, gensuha.rafsi, gensuha.hyphen, gensuha.payload)
-    else:
-      return '%s/%s' % (FUHIVLA, gensuha.type)
+    return '%s/%s' % (FUHIVLA, gensuha.type)
   elif isinstance(gensuha, Cmavo):
+    if simple:
+      return CMAVO
     return '%s/%s' % (CMAVO, gensuha.selmaho)
   elif isinstance(gensuha, ZeiLujvo):
     return ZEI_LUJVO
@@ -58,9 +61,11 @@ def classify_gensuha(gensuha):
   else:
     return NALVLA
 
-def classify_gensuha_sequence(gensuha):
+def classify_gensuha_sequence(gensuha, simple=False):
   if is_cmavo_sequence(gensuha):
-    return ' '.join(map(classify_gensuha, gensuha))
+    if simple:
+      return CMAVO_COMPOUND
+    return ' '.join(map(lambda g: classify_gensuha(g, simple), gensuha))
   else:
     return NALVLA
 

--- a/structures/jbovlaste_types.py
+++ b/structures/jbovlaste_types.py
@@ -2,7 +2,8 @@
 # pylint: disable=I0011, C0111, C0326
 
 from structures.gensuha \
-  import Cmevla, Gismu, Lujvo, Fuhivla, Fuhivla3, Fuhivla4, Cmavo, ZeiLujvo, BuLetteral, Tosmabru, Slinkuhi
+  import Cmevla, Gismu, Lujvo, Fuhivla, Fuhivla3, Fuhivla35, Fuhivla4, \
+         Cmavo, ZeiLujvo, BuLetteral, Tosmabru, Slinkuhi
 
 # legacy classifications
 CMEVLA        = "cmevla"
@@ -21,6 +22,7 @@ ZEI_LUJVO      = "zei-lujvo"
 TOSMABRU       = "valrtosmabru"
 SLINKUHI       = "valslinku'i"
 FUHIVLA3       = "type-3 fu'ivla"
+FUHIVLA35      = "type-3.5 fu'ivla"
 FUHIVLA4       = "type-4 fu'ivla"
 
 def classify(gensuha):
@@ -43,6 +45,8 @@ def classify_gensuha(gensuha):
         classified = FUHIVLA
     elif isinstance(gensuha, Fuhivla3):
         classified = FUHIVLA3
+    elif isinstance(gensuha, Fuhivla35):
+        classified = FUHIVLA35
     elif isinstance(gensuha, Fuhivla4):
         classified = FUHIVLA4
     elif isinstance(gensuha, Cmavo):

--- a/structures/jbovlaste_types.py
+++ b/structures/jbovlaste_types.py
@@ -54,19 +54,22 @@ def classify_gensuha(gensuha, simple=False):
   elif isinstance(gensuha, BuLetteral):
     return BU_LETTERAL
   elif isinstance(gensuha, Tosmabru):
-    return TOSMABRU
+    if simple:
+      return TOSMABRU
+    return '%s (%s)' % (TOSMABRU, classify_gensuha_sequence(gensuha.vlapoi))
   elif isinstance(gensuha, Slinkuhi):
     return SLINKUHI
   else:
     return NALVLA
 
 def classify_gensuha_sequence(gensuha, simple=False):
-  if is_cmavo_sequence(gensuha):
-    if simple:
+  if simple:
+    if is_cmavo_sequence(gensuha):
       return CMAVO_COMPOUND
-    return ' '.join(map(lambda g: classify_gensuha(g, simple), gensuha))
+    else:
+      return NALVLA
   else:
-    return NALVLA
+    return ' '.join(map(lambda g: '%s=%s' % (''.join(g.lerpoi), classify_gensuha(g, simple)), gensuha))
 
 def is_cmavo_sequence(gensuha):
     return all(isinstance(g, Cmavo) for g in gensuha)

--- a/structures/jbovlaste_types.py
+++ b/structures/jbovlaste_types.py
@@ -21,9 +21,6 @@ ZEI_LUJVO      = "zei-lujvo"
 # non-jvs types
 TOSMABRU       = "valrtosmabru"
 SLINKUHI       = "valslinku'i"
-FUHIVLA3       = "type-3 fu'ivla"
-FUHIVLA35      = "type-3.5 fu'ivla"
-FUHIVLA4       = "type-4 fu'ivla"
 
 def classify(gensuha, simple=False):
     if gensuha is None or len(gensuha) < 1:
@@ -39,7 +36,9 @@ def classify_gensuha(gensuha, simple=False):
   elif isinstance(gensuha, Gismu):
     return GISMU
   elif isinstance(gensuha, Lujvo):
-    return LUJVO
+    if simple:
+      return LUJVO
+    return '%s/%s' % (LUJVO, '-'.join(gensuha.rafsi))
   elif isinstance(gensuha, Fuhivla):
     if simple:
       return FUHIVLA

--- a/transformers/__init__.py
+++ b/transformers/__init__.py
@@ -1,0 +1,16 @@
+import re
+
+def find_all(node, regex):
+  if re.match(regex, node.expr_name) is not None:
+    yield node
+  else:
+    for child in node.children:
+      for f in find_all(child, regex):
+        yield f
+
+def find(node, regex):
+  try:
+    return next(find_all(node, regex))
+  except:
+    return None
+

--- a/transformers/camxes_morphology.py
+++ b/transformers/camxes_morphology.py
@@ -3,7 +3,6 @@
 
 import re
 
-from compiler.ast import flatten
 from transformers import find, find_all
 
 from parsimonious.nodes import NodeVisitor
@@ -20,8 +19,21 @@ def is_selmaho_expression(name):
     return re.match(r"^[ABCDFGIJKLMNPRSTUVXYZ]([AEIOUY]([IU]|h[AEIOU])?)?$", name)
 
 # flatten and join textual nodes
+def flatten(tree, collapse=False):
+    s = []
+    for t in tree:
+        if isinstance(t, str):
+            s += [t]
+        elif isinstance(t, Gensuha):
+            if collapse:
+                s += [t.lerpoi]
+            else:
+                s += [t]
+        else:
+            s += flatten(t, collapse)
+    return s
 def lerpoi(children):
-    return "".join(str(child) for child in flatten(children))
+    return "".join(flatten(children, True))
 
 class Transformer(object):
 
@@ -50,21 +62,6 @@ class Visitor(NodeVisitor):
 
     def visit_lujvo(self, node, visited_children):
         return Lujvo(lerpoi(visited_children), [r.text for r in find_all(node, r'(.*rafsi|gismu|fuhivla)')])
-
-    def visit_EOF(self, node, visited_children):
-        return []
-
-    def visit_CMEVLA(self, node, visited_children):
-        return Cmevla(lerpoi(visited_children))
-
-    def visit_BRIVLA(self, node, visited_children):
-        return flatten(visited_children)
-
-    def visit_gismu_2(self, node, visited_children):
-        return Gismu(lerpoi(visited_children))
-
-    def visit_lujvo(self, node, visited_children):
-        return Lujvo(lerpoi(visited_children))
 
     def visit_fuhivla(self, node, visited_children):
         return Fuhivla(lerpoi(visited_children))

--- a/transformers/camxes_morphology.py
+++ b/transformers/camxes_morphology.py
@@ -51,8 +51,11 @@ class Visitor(NodeVisitor):
     def visit_EOF(self, node, visited_children):
         return []
 
-    def visit_CMEVLA(self, node, visited_children):
-        return Cmevla(lerpoi(visited_children))
+    def visit_jbocme(self, node, visited_children):
+        return Cmevla(lerpoi(visited_children), 'jbocme')
+
+    def visit_zifcme(self, node, visited_children):
+        return Cmevla(lerpoi(visited_children), 'zifcme')
 
     def visit_BRIVLA(self, node, visited_children):
         return flatten(visited_children)

--- a/transformers/camxes_morphology.py
+++ b/transformers/camxes_morphology.py
@@ -12,7 +12,7 @@ from parsimonious_ext.expression_nodes import LITERAL, REGEX
 from structures.gensuha \
   import Gensuha, Cmevla, Gismu, Lujvo, Fuhivla, Cmavo, Naljbo
 
-SELMAHO_UNKNOWN = "TOLSLABU"
+SELMAHO_UNKNOWN = "EXP"
 SELMAHO_Y       = "Y"
 
 def is_selmaho_expression(name):

--- a/transformers/camxes_morphology.py
+++ b/transformers/camxes_morphology.py
@@ -4,6 +4,7 @@
 import re
 
 from compiler.ast import flatten
+from transformers import find, find_all
 
 from parsimonious.nodes import NodeVisitor
 
@@ -34,6 +35,21 @@ class Visitor(NodeVisitor):
 
     def visit_space_char(self, node, visited_children):
         return []
+
+    def visit_EOF(self, node, visited_children):
+        return []
+
+    def visit_CMEVLA(self, node, visited_children):
+        return Cmevla(lerpoi(visited_children))
+
+    def visit_BRIVLA(self, node, visited_children):
+        return flatten(visited_children)
+
+    def visit_gismu_2(self, node, visited_children):
+        return Gismu(lerpoi(visited_children))
+
+    def visit_lujvo(self, node, visited_children):
+        return Lujvo(lerpoi(visited_children), [r.text for r in find_all(node, r'(.*rafsi|gismu|fuhivla)')])
 
     def visit_EOF(self, node, visited_children):
         return []

--- a/transformers/camxes_morphology.py
+++ b/transformers/camxes_morphology.py
@@ -57,7 +57,7 @@ class Visitor(NodeVisitor):
     def visit_BRIVLA(self, node, visited_children):
         return flatten(visited_children)
 
-    def visit_gismu_2(self, node, visited_children):
+    def visit_gismu(self, node, visited_children):
         return Gismu(lerpoi(visited_children))
 
     def visit_lujvo(self, node, visited_children):

--- a/transformers/lujvo.py
+++ b/transformers/lujvo.py
@@ -47,7 +47,7 @@ class Visitor(NodeVisitor):
     if node.expr_name and ("rafsi" in node.expr_name or "gismu" in node.expr_name):
       if "rafsi" in node.expr_name:
         rafsi = node.text
-        if node.text[-1] == "y" or ("'" not in node.text and len(node.text) == 4):
+        if node.text[-1] == "y" or len(node.text.replace("'", "")) == 4:
           rafsi = node.text[:-1]
         if self.expand:
           return find(rafsi)

--- a/transformers/lujvo.py
+++ b/transformers/lujvo.py
@@ -12,7 +12,7 @@ def memoize(f):
     return memory[args]
   return g
 
-with open(os.path.join(os.path.dirname(sys.argv[0]), "jvs/en.xml")) as xml:
+with open(os.path.join(os.path.dirname(__file__), "../jvs/en.xml")) as xml:
   tree = et.parse(xml)
 
 @memoize

--- a/transformers/lujvo.py
+++ b/transformers/lujvo.py
@@ -45,11 +45,14 @@ class Visitor(NodeVisitor):
 
   def generic_visit(self, node, visited_children):
     if node.expr_name and ("rafsi" in node.expr_name or "gismu" in node.expr_name):
-      if self.expand and "rafsi" in node.expr_name:
-        if node.text[-1] == "y":
-          return find(node.text[:-1])
+      if "rafsi" in node.expr_name:
+        rafsi = node.text
+        if node.text[-1] == "y" or len(node.text) == 4:
+          rafsi = node.text[:-1]
+        if self.expand:
+          return find(rafsi)
         else:
-          return find(node.text)
+          return rafsi
       else:
         return node.text
     else:

--- a/transformers/lujvo.py
+++ b/transformers/lujvo.py
@@ -32,14 +32,20 @@ def find(rafsi):
 
 class Transformer:
 
+  def __init__(self, expand):
+    self.expand = expand
+
   def transform(self, parsed):
-    return Visitor().visit(parsed)
+    return Visitor(expand=self.expand).visit(parsed)
 
 class Visitor(NodeVisitor):
 
+  def __init__(self, expand):
+    self.expand = expand
+
   def generic_visit(self, node, visited_children):
     if node.expr_name and ("rafsi" in node.expr_name or "gismu" in node.expr_name):
-      if "rafsi" in node.expr_name:
+      if self.expand and "rafsi" in node.expr_name:
         if node.text[-1] == "y":
           return find(node.text[:-1])
         else:

--- a/transformers/lujvo.py
+++ b/transformers/lujvo.py
@@ -1,0 +1,52 @@
+from collections import OrderedDict
+from parsimonious.nodes import NodeVisitor
+from compiler.ast import flatten
+import lxml.etree as et
+import os, sys
+
+with open(os.path.join(os.path.dirname(sys.argv[0]), "jvs/en.xml")) as xml:
+  tree = et.parse(xml)
+
+known = {}
+def find(rafsi):
+  if rafsi in known:
+    return known[rafsi]
+
+  # short rafsi
+  results = tree.xpath('//rafsi[text()="%s"]' % rafsi)
+  if len(results) > 0:
+    r = results[0].getparent().get('word')
+    known[rafsi] = r
+    return r
+
+  # long rafsi
+  for vowel in 'aeiou':
+    results = tree.xpath('//valsi[@word="%s%s"]' % (rafsi, vowel))
+    if len(results) > 0:
+      r = results[0].get('word')
+      known[rafsi] = r
+      return r
+  
+  known[rafsi] = rafsi
+  return rafsi
+
+class Transformer:
+
+  def transform(self, parsed):
+    return Visitor().visit(parsed)
+
+class Visitor(NodeVisitor):
+
+  def generic_visit(self, node, visited_children):
+    if node.expr_name and ("rafsi" in node.expr_name or "gismu" in node.expr_name):
+      if "rafsi" in node.expr_name:
+        if node.text[-1] == "y":
+          return find(node.text[:-1])
+        else:
+          return find(node.text)
+      else:
+        return node.text
+    else:
+      return flatten(visited_children)
+
+

--- a/transformers/lujvo.py
+++ b/transformers/lujvo.py
@@ -47,7 +47,7 @@ class Visitor(NodeVisitor):
     if node.expr_name and ("rafsi" in node.expr_name or "gismu" in node.expr_name):
       if "rafsi" in node.expr_name:
         rafsi = node.text
-        if node.text[-1] == "y" or len(node.text) == 4:
+        if node.text[-1] == "y" or ("'" not in node.text and len(node.text) == 4):
           rafsi = node.text[:-1]
         if self.expand:
           return find(rafsi)

--- a/transformers/lujvo.py
+++ b/transformers/lujvo.py
@@ -4,30 +4,30 @@ from compiler.ast import flatten
 import lxml.etree as et
 import os, sys
 
+def memoize(f):
+  memory = {}
+  def g(*args):
+    if args not in memory:
+      memory[args] = f(*args)
+    return memory[args]
+  return g
+
 with open(os.path.join(os.path.dirname(sys.argv[0]), "jvs/en.xml")) as xml:
   tree = et.parse(xml)
 
-known = {}
+@memoize
 def find(rafsi):
-  if rafsi in known:
-    return known[rafsi]
-
   # short rafsi
   results = tree.xpath('//rafsi[text()="%s"]' % rafsi)
   if len(results) > 0:
-    r = results[0].getparent().get('word')
-    known[rafsi] = r
-    return r
+    return results[0].getparent().get('word')
 
   # long rafsi
   for vowel in 'aeiou':
     results = tree.xpath('//valsi[@word="%s%s"]' % (rafsi, vowel))
     if len(results) > 0:
-      r = results[0].get('word')
-      known[rafsi] = r
-      return r
+      return results[0].get('word')
   
-  known[rafsi] = rafsi
   return rafsi
 
 class Transformer:
@@ -48,5 +48,6 @@ class Visitor(NodeVisitor):
         return node.text
     else:
       return flatten(visited_children)
+
 
 

--- a/transformers/syllable.py
+++ b/transformers/syllable.py
@@ -1,0 +1,29 @@
+from parsimonious.nodes import NodeVisitor
+from compiler.ast import flatten
+from transformers import find_all
+
+class Transformer:
+
+  def __init__(self, trim):
+    self.trim = trim
+
+  def transform(self, parsed):
+    return Visitor(self.trim).visit(parsed)
+
+class Visitor(NodeVisitor):
+
+  def __init__(self, trim):
+    self.trim = trim
+
+  def generic_visit(self, node, visited_children):
+    if node.expr_name and 'syllable' in node.expr_name:
+      if self.trim < 0 and node.end == len(node.full_text):
+        return node.text[:self.trim]
+      if self.trim > 0 and node.start < self.trim:
+        return node.text[self.trim:]
+      return node.text
+    else:
+      return flatten(visited_children)
+
+
+

--- a/transformers/syllable.py
+++ b/transformers/syllable.py
@@ -15,13 +15,27 @@ class Visitor(NodeVisitor):
   def __init__(self, trim):
     self.trim = trim
 
+  def visit_fuhivla(self, node, visited_children):
+    return self.finish(visited_children)
+  def visit_jbocme(self, node, visited_children):
+    return self.finish(visited_children)
+
+  def finish(self, visited_children):
+    return '-'.join(filter(lambda x: len(x) > 0, flatten(visited_children)))
+
   def generic_visit(self, node, visited_children):
     if node.expr_name and 'syllable' in node.expr_name:
+      if node.expr_name.startswith('stressed') or any(map(lambda c: c in node.text, 'AEIOU')):
+        text = node.text.upper()
+      else:
+        text = node.text
+
       if self.trim < 0 and node.end == len(node.full_text):
-        return node.text[:self.trim]
+        return text[:self.trim]
       if self.trim > 0 and node.start < self.trim:
-        return node.text[self.trim:]
-      return node.text
+        return text[(self.trim-node.start):]
+      return text
+
     else:
       return flatten(visited_children)
 

--- a/transformers/syllable.py
+++ b/transformers/syllable.py
@@ -15,13 +15,18 @@ class Visitor(NodeVisitor):
   def __init__(self, trim):
     self.trim = trim
 
-  def visit_fuhivla(self, node, visited_children):
-    return self.finish(visited_children)
-  def visit_jbocme(self, node, visited_children):
-    return self.finish(visited_children)
-
-  def finish(self, visited_children):
+  def visit_fuhivla_any(self, node, visited_children):
     return '-'.join(filter(lambda x: len(x) > 0, flatten(visited_children)))
+
+  def visit_jbocme(self, node, visited_children):
+    kids = filter(lambda x: len(x) > 0, flatten(visited_children))
+    if not any(map(lambda k: any(map(lambda c: c in k, 'AEIOU')), kids)):
+      i = len(kids)-2
+      while i > 0 and 'y' in kids[i]:
+        i -= 1
+      if i > 0:
+        kids[i] = kids[i].upper()
+    return '-'.join(kids)
 
   def generic_visit(self, node, visited_children):
     if node.expr_name and 'syllable' in node.expr_name:

--- a/transformers/syllable.py
+++ b/transformers/syllable.py
@@ -22,7 +22,7 @@ class Visitor(NodeVisitor):
     kids = filter(lambda x: len(x) > 0, flatten(visited_children))
     if not any(map(lambda k: any(map(lambda c: c in k, 'AEIOU')), kids)):
       i = len(kids)-2
-      while i > 0 and (not any(map(lambda c: c in kids[i], 'aeiou')) or 'y' in kids[i]):
+      while i >= 0 and (not any(map(lambda c: c in kids[i], 'aeiou')) or 'y' in kids[i]):
         i -= 1
       if i >= 0:
         kids[i] = kids[i].upper()

--- a/transformers/syllable.py
+++ b/transformers/syllable.py
@@ -17,11 +17,13 @@ class Visitor(NodeVisitor):
 
   def visit_jbocme(self, node, visited_children):
     kids = filter(lambda x: len(x) > 0, flatten(visited_children))
-    if not any(map(lambda k: any(map(lambda c: c in k, 'AEIOU')), kids)):
-      i = len(kids)-2
-      while i >= 0 and (not any(map(lambda c: c in kids[i], 'aeiou')) or 'y' in kids[i]):
-        i -= 1
-      if i >= 0:
+    if not any(map(lambda k: any(map(lambda c: c in k, 'AEIOUY')), kids)):
+      vocalic_kids = filter(lambda k: 'y' not in k[1]
+                                      and any(map(lambda v: v in k[1],
+                                                  'aeiou')),
+                            zip(range(len(kids)), kids))
+      if len(vocalic_kids) > 1:
+        i = vocalic_kids[-2][0]
         kids[i] = kids[i].upper()
     return ','.join(kids)
 

--- a/transformers/syllable.py
+++ b/transformers/syllable.py
@@ -22,9 +22,9 @@ class Visitor(NodeVisitor):
     kids = filter(lambda x: len(x) > 0, flatten(visited_children))
     if not any(map(lambda k: any(map(lambda c: c in k, 'AEIOU')), kids)):
       i = len(kids)-2
-      while i > 0 and 'y' in kids[i]:
+      while i > 0 and (not any(map(lambda c: c in kids[i], 'aeiou')) or 'y' in kids[i]):
         i -= 1
-      if i > 0:
+      if i >= 0:
         kids[i] = kids[i].upper()
     return '-'.join(kids)
 

--- a/transformers/syllable.py
+++ b/transformers/syllable.py
@@ -16,7 +16,7 @@ class Visitor(NodeVisitor):
     self.trim = trim
 
   def visit_fuhivla_any(self, node, visited_children):
-    return '-'.join(filter(lambda x: len(x) > 0, flatten(visited_children)))
+    return ','.join(filter(lambda x: len(x) > 0, flatten(visited_children)))
 
   def visit_jbocme(self, node, visited_children):
     kids = filter(lambda x: len(x) > 0, flatten(visited_children))

--- a/transformers/syllable.py
+++ b/transformers/syllable.py
@@ -28,6 +28,12 @@ class Visitor(NodeVisitor):
         kids[i] = kids[i].upper()
     return '-'.join(kids)
 
+  def visit_zifcme(self, node, visited_children):
+    raise Exception('zifcme')
+
+  def visit_cmevla(self, node, visited_children):
+    return visited_children[0]
+
   def generic_visit(self, node, visited_children):
     if node.expr_name and 'syllable' in node.expr_name:
       if node.expr_name.startswith('stressed') or any(map(lambda c: c in node.text, 'AEIOU')):

--- a/transformers/syllable.py
+++ b/transformers/syllable.py
@@ -28,7 +28,8 @@ class Visitor(NodeVisitor):
     return ','.join(kids)
 
   def visit_zifcme(self, node, visited_children):
-    return node.text
+    if self.trim == 0:
+      return node.text
 
   def visit_cmevla(self, node, visited_children):
     return visited_children[0]

--- a/transformers/syllable.py
+++ b/transformers/syllable.py
@@ -23,7 +23,7 @@ class Visitor(NodeVisitor):
         i -= 1
       if i >= 0:
         kids[i] = kids[i].upper()
-    return '-'.join(kids)
+    return ','.join(kids)
 
   def visit_zifcme(self, node, visited_children):
     raise Exception('zifcme')

--- a/transformers/syllable.py
+++ b/transformers/syllable.py
@@ -17,7 +17,7 @@ class Visitor(NodeVisitor):
 
   def visit_jbocme(self, node, visited_children):
     kids = filter(lambda x: len(x) > 0, flatten(visited_children))
-    if not any(map(lambda k: any(map(lambda c: c in k, 'AEIOUY')), kids)):
+    if not any(map(lambda k: any(map(lambda c: c.isupper(), k)), kids)):
       vocalic_kids = filter(lambda k: 'y' not in k[1]
                                       and any(map(lambda v: v in k[1],
                                                   'aeiou')),
@@ -34,7 +34,7 @@ class Visitor(NodeVisitor):
     return visited_children[0]
 
   def visit_any_syllable(self, node, visited_children):
-    if any(map(lambda c: c in node.text, 'AEIOU')):
+    if any(map(lambda c: c.isupper(), node.text)):
       text = node.text.upper()
     else:
       text = node.text

--- a/transformers/syllable.py
+++ b/transformers/syllable.py
@@ -15,9 +15,6 @@ class Visitor(NodeVisitor):
   def __init__(self, trim):
     self.trim = trim
 
-  def visit_fuhivla_any(self, node, visited_children):
-    return ','.join(filter(lambda x: len(x) > 0, flatten(visited_children)))
-
   def visit_jbocme(self, node, visited_children):
     kids = filter(lambda x: len(x) > 0, flatten(visited_children))
     if not any(map(lambda k: any(map(lambda c: c in k, 'AEIOU')), kids)):
@@ -34,21 +31,19 @@ class Visitor(NodeVisitor):
   def visit_cmevla(self, node, visited_children):
     return visited_children[0]
 
-  def generic_visit(self, node, visited_children):
-    if node.expr_name and 'syllable' in node.expr_name:
-      if node.expr_name.startswith('stressed') or any(map(lambda c: c in node.text, 'AEIOU')):
-        text = node.text.upper()
-      else:
-        text = node.text
-
-      if self.trim < 0 and node.end == len(node.full_text):
-        return text[:self.trim]
-      if self.trim > 0 and node.start < self.trim:
-        return text[(self.trim-node.start):]
-      return text
-
+  def visit_any_syllable(self, node, visited_children):
+    if any(map(lambda c: c in node.text, 'AEIOU')):
+      text = node.text.upper()
     else:
-      return flatten(visited_children)
+      text = node.text
 
+    if self.trim < 0 and node.end == len(node.full_text):
+      return text[:self.trim]
+    if self.trim > 0 and node.start < self.trim:
+      return text[(self.trim-node.start):]
+    return text
+
+  def generic_visit(self, node, visited_children):
+    return flatten(visited_children)
 
 

--- a/transformers/syllable.py
+++ b/transformers/syllable.py
@@ -28,7 +28,7 @@ class Visitor(NodeVisitor):
     return ','.join(kids)
 
   def visit_zifcme(self, node, visited_children):
-    raise Exception('zifcme')
+    return node.text
 
   def visit_cmevla(self, node, visited_children):
     return visited_children[0]

--- a/transformers/syllable.py
+++ b/transformers/syllable.py
@@ -25,6 +25,9 @@ class Visitor(NodeVisitor):
       if len(vocalic_kids) > 1:
         i = vocalic_kids[-2][0]
         kids[i] = kids[i].upper()
+      elif len(vocalic_kids) == 1:
+        i = vocalic_kids[-1][0]
+        kids[i] = kids[i].upper()
     return ','.join(kids)
 
   def visit_zifcme(self, node, visited_children):

--- a/transformers/vlatai.py
+++ b/transformers/vlatai.py
@@ -38,25 +38,26 @@ class Visitor(camxes_morphology.Visitor):
     def visit_fuhivla(self, node, visited_children):
         if len(node.text) >= 5:
             C = r'[bcdfgjklmnprstvxz]'
+            Ce = r'^([bcdfgjklmnprstvxz].?|[ui][aeiou])'
             V = r'[aeiou]'
             hyphen = r'[^r]r[^r]|[rl]n[^n]|[^n]n[rl]|[rn]l[^l]|[^l]l[rn]'
             
             if len(node.text) >= 6:
-                if ((    re.match(C+C+V+C, node.text[:4], re.I)
+                if ((  re.match(C+C+V+C, node.text[:4], re.I)
                       or re.match(C+V+C+C, node.text[:4], re.I))
                      and re.match(hyphen, node.text[3:6], re.I)
-                     and re.match(C, node.text[5], re.I)):
-                    return Fuhivla3(flatten(visited_children), node.text[:4], node.text[4], node.text[5:])
+                     and re.match(Ce, node.text[5:], re.I)):
+                    return Fuhivla3(flatten(visited_children), node.text[:4], node.text[5:])
 
                 if (    re.match(C+C+V, node.text[:3], re.I)
                     and re.match(hyphen, node.text[2:5], re.I)
-                    and re.match(C, node.text[4], re.I)):
-                    return Fuhivla35(flatten(visited_children), node.text[:3], node.text[3], node.text[4:])
+                    and re.match(Ce, node.text[4], re.I)):
+                    return Fuhivla35(flatten(visited_children), node.text[:3], node.text[4:])
 
             if (    re.match(C+V+C, node.text[:3], re.I)
                 and re.match(hyphen, node.text[2:5], re.I)
-                and re.match(C, node.text[4], re.I)):
-                return Fuhivla3(flatten(visited_children), node.text[:3], node.text[3], node.text[4:])
+                and re.match(Ce, node.text[4], re.I)):
+                return Fuhivla3(flatten(visited_children), node.text[:3], node.text[4:])
 
         return Fuhivla4(flatten(visited_children))
 

--- a/transformers/vlatai.py
+++ b/transformers/vlatai.py
@@ -38,25 +38,25 @@ class Visitor(camxes_morphology.Visitor):
     def visit_fuhivla(self, node, visited_children):
         if len(node.text) >= 5:
             C = r'[bcdfgjklmnprstvxz]'
-            Ce = r'^([bcdfgjklmnprstvxz].?|[ui][aeiou])'
+            Ce = r'^([bcdfgjklmnprstvxz].?|[ui][aeiou]($|[^aeiou]))'
             V = r'[aeiou]'
             hyphen = r'[^r]r[^r]|[rl]n[^n]|[^n]n[rl]|[rn]l[^l]|[^l]l[rn]'
             
             if len(node.text) >= 6:
-                if ((  re.match(C+C+V+C, node.text[:4], re.I)
-                      or re.match(C+V+C+C, node.text[:4], re.I))
-                     and re.match(hyphen, node.text[3:6], re.I)
-                     and re.match(Ce, node.text[5:], re.I)):
+                if ((     re.match(C+C+V+C, node.text[:4], re.I)
+                         or re.match(C+V+C+C, node.text[:4], re.I))
+                        and re.match(hyphen, node.text[3:6], re.I)
+                        and re.match(Ce, node.text[5:], re.I)):
                     return Fuhivla3(flatten(visited_children), node.text[:4], node.text[5:])
 
-                if (    re.match(C+C+V, node.text[:3], re.I)
-                    and re.match(hyphen, node.text[2:5], re.I)
-                    and re.match(Ce, node.text[4], re.I)):
+                if (        re.match(C+C+V, node.text[:3], re.I)
+                        and re.match(hyphen, node.text[2:5], re.I)
+                        and re.match(Ce, node.text[4:], re.I)):
                     return Fuhivla35(flatten(visited_children), node.text[:3], node.text[4:])
 
-            if (    re.match(C+V+C, node.text[:3], re.I)
-                and re.match(hyphen, node.text[2:5], re.I)
-                and re.match(Ce, node.text[4], re.I)):
+            if (        re.match(C+V+C, node.text[:3], re.I)
+                    and re.match(hyphen, node.text[2:5], re.I)
+                    and re.match(Ce, node.text[4:], re.I)):
                 return Fuhivla3(flatten(visited_children), node.text[:3], node.text[4:])
 
         return Fuhivla4(flatten(visited_children))

--- a/transformers/vlatai.py
+++ b/transformers/vlatai.py
@@ -4,7 +4,7 @@
 from compiler.ast import flatten
 
 from transformers import camxes_morphology
-from structures.gensuha import BuLetteral, ZeiLujvo, Tosmabru, Slinkuhi
+from structures.gensuha import BuLetteral, ZeiLujvo, Tosmabru, Slinkuhi, Fuhivla3, Fuhivla4
 
 class Transformer(object):
 
@@ -30,4 +30,10 @@ class Visitor(camxes_morphology.Visitor):
 
     def visit_vlatai_zei_clause(self, node, visited_children):
         return ZeiLujvo(flatten(visited_children))
+
+    def visit_vlatai_type3_fuhivla(self, node, visited_children):
+        return Fuhivla3(flatten(visited_children))
+
+    def visit_vlatai_type4_fuhivla(self, node, visited_children):
+        return Fuhivla4(flatten(visited_children))
 

--- a/transformers/vlatai.py
+++ b/transformers/vlatai.py
@@ -3,6 +3,7 @@
 
 import re
 from compiler.ast import flatten
+from transformers.camxes_morphology import flatten
 
 from transformers import camxes_morphology, find
 from structures.gensuha import BuLetteral, ZeiLujvo, Tosmabru, Slinkuhi, Fuhivla3, Fuhivla35, Fuhivla4

--- a/transformers/vlatai.py
+++ b/transformers/vlatai.py
@@ -4,7 +4,7 @@
 import re
 from compiler.ast import flatten
 
-from transformers import camxes_morphology
+from transformers import camxes_morphology, find
 from structures.gensuha import BuLetteral, ZeiLujvo, Tosmabru, Slinkuhi, Fuhivla3, Fuhivla35, Fuhivla4
 
 class Transformer(object):
@@ -14,16 +14,6 @@ class Transformer(object):
 
     def default_serializer(self):
         return lambda x: x.as_json()
-
-def find(node, regex):
-  if re.match(regex, node.expr_name) is not None:
-    return node
-  else:
-    for child in node.children:
-      f = find(child, regex)
-      if f is not None:
-        return f
-  return None
 
 class Visitor(camxes_morphology.Visitor):
 

--- a/transformers/vlatai.py
+++ b/transformers/vlatai.py
@@ -3,7 +3,6 @@
 
 import re
 from compiler.ast import flatten
-import re
 
 from parsers import camxes_ilmen
 from transformers.camxes_morphology import flatten
@@ -43,22 +42,24 @@ class Visitor(camxes_morphology.Visitor):
         return ZeiLujvo(flatten(visited_children))
 
     def visit_fuhivla(self, node, visited_children):
-        if len(node.text) >= 6:
-            if (  swallow(lambda: camxes_ilmen.Parser('long_rafsi').parse(node.text[:4]),          None) is not None
-               or swallow(lambda: camxes_ilmen.Parser('stressed_long_rafsi').parse(node.text[:4]), None) is not None):
-                if re.match(r'[^r]r[^r]|[rl]n[^n]|[^n]n[rl]|[rn]l[^l]|[^l]l[rn]', node.text[3:6]):
+        if len(node.text) >= 5:
+            C = r'[bcdfgjklmnprstvxz]'
+            V = r'[aeiou]'
+            hyphen = r'[^r]r[^r]|[rl]n[^n]|[^n]n[rl]|[rn]l[^l]|[^l]l[rn]'
+            
+            if len(node.text) >= 6:
+                if ((     re.match(C+C+V+C, node.text[:4], re.I)
+                         or re.match(C+V+C+C, node.text[:4], re.I))
+                        and re.match(hyphen, node.text[3:6], re.I)):
                     return Fuhivla3(flatten(visited_children), node.text[:4], node.text[4], node.text[5:])
 
-            if (  swallow(lambda: camxes_ilmen.Parser('CCV_rafsi').parse(node.text[:3]),          None) is not None
-               or swallow(lambda: camxes_ilmen.Parser('stressed_CCV_rafsi').parse(node.text[:3]), None) is not None):
-                if re.match(r'[^r]r[^r]|[rl]n[^n]|[^n]n[rl]|[rn]l[^l]|[^l]l[rn]', node.text[2:5]):
+                if (        re.match(C+C+V, node.text[:3], re.I)
+                        and re.match(hyphen, node.text[2:5], re.I)):
                     return Fuhivla35(flatten(visited_children), node.text[:3], node.text[3], node.text[4:])
 
-        if len(node.text) >= 5:
-            if (  swallow(lambda: camxes_ilmen.Parser('CVC_rafsi').parse(node.text[:3]),          None) is not None
-               or swallow(lambda: camxes_ilmen.Parser('stressed_CVC_rafsi').parse(node.text[:3]), None) is not None):
-                if re.match(r'[^r]r[^r]|[rl]n[^n]|[^n]n[rl]|[rn]l[^l]|[^l]l[rn]', node.text[2:5]):
-                    return Fuhivla3(flatten(visited_children), node.text[:3], node.text[3], node.text[4:])
+            if (        re.match(C+V+C, node.text[:3], re.I)
+                    and re.match(hyphen, node.text[2:5], re.I)):
+                return Fuhivla3(flatten(visited_children), node.text[:3], node.text[3], node.text[4:])
 
         return Fuhivla4(flatten(visited_children))
 

--- a/transformers/vlatai.py
+++ b/transformers/vlatai.py
@@ -1,6 +1,7 @@
 
 # pylint: disable=I0011, C0111, no-self-use, unused-argument
 
+import re
 from compiler.ast import flatten
 
 from transformers import camxes_morphology
@@ -13,6 +14,16 @@ class Transformer(object):
 
     def default_serializer(self):
         return lambda x: x.as_json()
+
+def find(node, regex):
+  if re.match(regex, node.expr_name) is not None:
+    return node
+  else:
+    for child in node.children:
+      f = find(child, regex)
+      if f is not None:
+        return f
+  return None
 
 class Visitor(camxes_morphology.Visitor):
 
@@ -32,10 +43,16 @@ class Visitor(camxes_morphology.Visitor):
         return ZeiLujvo(flatten(visited_children))
 
     def visit_vlatai_type3_fuhivla(self, node, visited_children):
-        return Fuhivla3(flatten(visited_children))
+        a = find(node, r'(stressed_)?(long|CVC)_rafsi').text
+        b = find(node, r'vlatai_fuhivla_hyphen').text
+        c = node.text[(len(a)+len(b)):]
+        return Fuhivla3(flatten(visited_children), a, b, c)
 
     def visit_vlatai_type35_fuhivla(self, node, visited_children):
-        return Fuhivla35(flatten(visited_children))
+        a = find(node, r'(stressed_)?CCV_rafsi').text
+        b = find(node, r'vlatai_fuhivla_hyphen').text
+        c = node.text[(len(a)+len(b)):]
+        return Fuhivla35(flatten(visited_children), a, b, c)
 
     def visit_vlatai_type4_fuhivla(self, node, visited_children):
         return Fuhivla4(flatten(visited_children))

--- a/transformers/vlatai.py
+++ b/transformers/vlatai.py
@@ -26,7 +26,7 @@ class Visitor(camxes_morphology.Visitor):
     def visit_tosmabru(self, node, visited_children):
         return Tosmabru(flatten(visited_children))
 
-    def visit_slinkuhi_no_recurse(self, node, visited_children):
+    def visit_slinkuhi(self, node, visited_children):
         return Slinkuhi(flatten(visited_children))
 
     def visit_vlatai_bu_clause(self, node, visited_children):

--- a/transformers/vlatai.py
+++ b/transformers/vlatai.py
@@ -42,17 +42,20 @@ class Visitor(camxes_morphology.Visitor):
             hyphen = r'[^r]r[^r]|[rl]n[^n]|[^n]n[rl]|[rn]l[^l]|[^l]l[rn]'
             
             if len(node.text) >= 6:
-                if ((     re.match(C+C+V+C, node.text[:4], re.I)
-                       or re.match(C+V+C+C, node.text[:4], re.I))
-                      and re.match(hyphen, node.text[3:6], re.I)):
+                if ((    re.match(C+C+V+C, node.text[:4], re.I)
+                      or re.match(C+V+C+C, node.text[:4], re.I))
+                     and re.match(hyphen, node.text[3:6], re.I)
+                     and re.match(C, node.text[5], re.I)):
                     return Fuhivla3(flatten(visited_children), node.text[:4], node.text[4], node.text[5:])
 
-                if (    re.match(C+C+V,  node.text[:3], re.I)
-                    and re.match(hyphen, node.text[2:5], re.I)):
+                if (    re.match(C+C+V, node.text[:3], re.I)
+                    and re.match(hyphen, node.text[2:5], re.I)
+                    and re.match(C, node.text[4], re.I)):
                     return Fuhivla35(flatten(visited_children), node.text[:3], node.text[3], node.text[4:])
 
-            if (    re.match(C+V+C,  node.text[:3], re.I)
-                and re.match(hyphen, node.text[2:5], re.I)):
+            if (    re.match(C+V+C, node.text[:3], re.I)
+                and re.match(hyphen, node.text[2:5], re.I)
+                and re.match(C, node.text[4], re.I)):
                 return Fuhivla3(flatten(visited_children), node.text[:3], node.text[3], node.text[4:])
 
         return Fuhivla4(flatten(visited_children))

--- a/transformers/vlatai.py
+++ b/transformers/vlatai.py
@@ -4,7 +4,7 @@
 from compiler.ast import flatten
 
 from transformers import camxes_morphology
-from structures.gensuha import BuLetteral, ZeiLujvo, Tosmabru, Slinkuhi, Fuhivla3, Fuhivla4
+from structures.gensuha import BuLetteral, ZeiLujvo, Tosmabru, Slinkuhi, Fuhivla3, Fuhivla35, Fuhivla4
 
 class Transformer(object):
 
@@ -33,6 +33,9 @@ class Visitor(camxes_morphology.Visitor):
 
     def visit_vlatai_type3_fuhivla(self, node, visited_children):
         return Fuhivla3(flatten(visited_children))
+
+    def visit_vlatai_type35_fuhivla(self, node, visited_children):
+        return Fuhivla35(flatten(visited_children))
 
     def visit_vlatai_type4_fuhivla(self, node, visited_children):
         return Fuhivla4(flatten(visited_children))

--- a/transformers/vlatai.py
+++ b/transformers/vlatai.py
@@ -32,7 +32,7 @@ class Visitor(camxes_morphology.Visitor):
     def visit_tosmabru(self, node, visited_children):
         return Tosmabru(flatten(visited_children))
 
-    def visit_slinkuhi(self, node, visited_children):
+    def visit_slinkuhi_no_recurse(self, node, visited_children):
         return Slinkuhi(flatten(visited_children))
 
     def visit_vlatai_bu_clause(self, node, visited_children):
@@ -61,20 +61,5 @@ class Visitor(camxes_morphology.Visitor):
                     and re.match(hyphen, node.text[2:5], re.I)):
                 return Fuhivla3(flatten(visited_children), node.text[:3], node.text[3], node.text[4:])
 
-        return Fuhivla4(flatten(visited_children))
-
-    def visit_vlatai_type3_fuhivla(self, node, visited_children):
-        a = find(node, r'(stressed_)?(long|CVC)_rafsi').text
-        b = find(node, r'vlatai_fuhivla_hyphen').text
-        c = node.text[(len(a)+len(b)):]
-        return Fuhivla3(flatten(visited_children), a, b, c)
-
-    def visit_vlatai_type35_fuhivla(self, node, visited_children):
-        a = find(node, r'(stressed_)?CCV_rafsi').text
-        b = find(node, r'vlatai_fuhivla_hyphen').text
-        c = node.text[(len(a)+len(b)):]
-        return Fuhivla35(flatten(visited_children), a, b, c)
-
-    def visit_vlatai_type4_fuhivla(self, node, visited_children):
         return Fuhivla4(flatten(visited_children))
 

--- a/transformers/vlatai.py
+++ b/transformers/vlatai.py
@@ -10,12 +10,6 @@ from transformers.camxes_morphology import flatten
 from transformers import camxes_morphology, find
 from structures.gensuha import BuLetteral, ZeiLujvo, Tosmabru, Slinkuhi, Fuhivla3, Fuhivla35, Fuhivla4
 
-def swallow(fn, ret):
-    try:
-        return fn()
-    except:
-        return ret
-
 class Transformer(object):
 
     def transform(self, parsed):
@@ -49,16 +43,16 @@ class Visitor(camxes_morphology.Visitor):
             
             if len(node.text) >= 6:
                 if ((     re.match(C+C+V+C, node.text[:4], re.I)
-                         or re.match(C+V+C+C, node.text[:4], re.I))
-                        and re.match(hyphen, node.text[3:6], re.I)):
+                       or re.match(C+V+C+C, node.text[:4], re.I))
+                      and re.match(hyphen, node.text[3:6], re.I)):
                     return Fuhivla3(flatten(visited_children), node.text[:4], node.text[4], node.text[5:])
 
-                if (        re.match(C+C+V, node.text[:3], re.I)
-                        and re.match(hyphen, node.text[2:5], re.I)):
+                if (    re.match(C+C+V,  node.text[:3], re.I)
+                    and re.match(hyphen, node.text[2:5], re.I)):
                     return Fuhivla35(flatten(visited_children), node.text[:3], node.text[3], node.text[4:])
 
-            if (        re.match(C+V+C, node.text[:3], re.I)
-                    and re.match(hyphen, node.text[2:5], re.I)):
+            if (    re.match(C+V+C,  node.text[:3], re.I)
+                and re.match(hyphen, node.text[2:5], re.I)):
                 return Fuhivla3(flatten(visited_children), node.text[:3], node.text[3], node.text[4:])
 
         return Fuhivla4(flatten(visited_children))

--- a/vlatai.py
+++ b/vlatai.py
@@ -14,8 +14,10 @@ from transformers.vlatai import Visitor
 VLATAI_RULE = "vlatai"
 
 def main(text, simple):
+    parser = build_parser()
+    visitor = Visitor()
     for word in text:
-        gensuha = analyze_morphology(build_parser(), word)
+        gensuha = analyze_morphology(parser, visitor, word)
         velski = jbovlaste_types.classify(gensuha, simple)
         if simple:
             print velski
@@ -25,13 +27,12 @@ def main(text, simple):
 def build_parser():
     return Parser(VLATAI_RULE)
 
-def analyze_morphology(parser, text):
-    visitor = Visitor()
+def analyze_morphology(parser, visitor, text):
     gensuha = None
     try:
         parsed = parser.parse(text)
         gensuha = visitor.visit(parsed)
-    except ParseError:
+    except ParseError as e:
         pass
     return gensuha
 

--- a/vlatai.py
+++ b/vlatai.py
@@ -13,10 +13,14 @@ from transformers.vlatai import Visitor
 
 VLATAI_RULE = "vlatai"
 
-def main(text):
+def main(text, simple):
     for word in text:
         gensuha = analyze_morphology(build_parser(), word)
-        print '%s:' % word, jbovlaste_types.classify(gensuha)
+        velski = jbovlaste_types.classify(gensuha, simple)
+        if simple:
+            print velski
+        else:
+            print '%s:' % word, velski
 
 def build_parser():
     return Parser(VLATAI_RULE)
@@ -32,9 +36,19 @@ def analyze_morphology(parser, text):
     return gensuha
 
 if __name__ == '__main__':
-    import sys
     import itertools
-    text = itertools.chain(*map(lambda s: s.split(' '), sys.argv[1:]))
+
+    from optparse import OptionParser
+    from camxes import VERSION
+    usage_fmt = "usage: %prog [ options ] { input }"
+    options = OptionParser(usage=usage_fmt, version="%prog " + VERSION)
+    options.add_option("-s", "--simple",
+                                         help="enable simple output (for jbovlaste)",
+                                         action="store_true",
+                                         dest="simple")
+    (params, argv) = options.parse_args()
+
+    text = itertools.chain(*map(lambda s: s.split(' '), argv))
     configure_platform()
-    main(text)
+    main(text, params.simple)
 

--- a/vlatai.py
+++ b/vlatai.py
@@ -36,8 +36,6 @@ def analyze_morphology(parser, text):
     return gensuha
 
 if __name__ == '__main__':
-    import itertools
-
     from optparse import OptionParser
     from camxes import VERSION
     usage_fmt = "usage: %prog [ options ] { input }"
@@ -48,7 +46,6 @@ if __name__ == '__main__':
                                          dest="simple")
     (params, argv) = options.parse_args()
 
-    text = itertools.chain(*map(lambda s: s.split(' '), argv))
     configure_platform()
-    main(text, params.simple)
+    main(argv, params.simple)
 

--- a/vlatai.py
+++ b/vlatai.py
@@ -13,10 +13,10 @@ from transformers.vlatai import Visitor
 
 VLATAI_RULE = "vlatai"
 
-def run(text):
-    parser = build_parser()
-    gensuha = analyze_morphology(parser, text)
-    print jbovlaste_types.classify(gensuha)
+def main(text):
+    for word in text:
+        gensuha = analyze_morphology(build_parser(), word)
+        print '%s:' % word, jbovlaste_types.classify(gensuha)
 
 def build_parser():
     return Parser(VLATAI_RULE)
@@ -31,10 +31,10 @@ def analyze_morphology(parser, text):
         pass
     return gensuha
 
-def _main():
-    configure_platform()
-    text = " ".join(sys.argv[1:])
-    run(text)
-
 if __name__ == '__main__':
-    _main()
+    import sys
+    import itertools
+    text = itertools.chain(*map(lambda s: s.split(' '), sys.argv[1:]))
+    configure_platform()
+    main(text)
+


### PR DESCRIPTION
I'm not trying to suggest that this branch is ready to pull, but I wanted to share what I've been working on...
- jvocuhadju.py is added. The idea is not to encode all the lujvo-building rules, but to use the parser to determine which rafsi+hyphen combinations are well-formed. This makes it quite slow, but it seems to work. I implemented the scoring algorithm from the Book.
- vlatai.py got a lot smarter, knowing how to decompose lujvo (even with extended rafsi), type-3 fu'ivla, tosmabru, and cmavo compounds, and showing selma'o in the output. All this can be turned off with `-s`/`--simple` to get the output jbovlaste expects.
- two new transformers: lujvo-break (which returns the bare rafsi) and lujvo-expand (which uses a jbovlaste dump to look up gismu). (Currently vlatai.py uses a different method for breaking lujvo. I mean to merge these.)
- another new transformer: syllable, which splits a word into syllables. It does this for non-cmevla by prepending valr- or valrx- (to parse as fu'ivla) and trimming it off later.
- la xorxes' consonontal_syllable morphology fix is included.

A fair amount of code is duplicated between my additions here and my additions to the ilmentufa IRC bot. I may try to factor them out into a library, but finding the boundary will be tricky since the parser internals are different.

Todo list before a hypothetical merge:
- [ ] test to find bugs
- [ ] comment the code
- [ ] rebase into a reasonable number of commits (and on top of master)
- [ ] factor out into separate library?
