### PR TITLE
fix vlatai crash from trying to convert Lerpoi to str

### DIFF
--- a/structures/gensuha.py
+++ b/structures/gensuha.py
@@ -41,6 +41,9 @@ class Lerpoi(Gensuha):
       ( "lerpoi",    self.lerpoi    )
     ])
 
+  def __str__(self):
+    return self.lerpoi
+
 class Naljbo(Lerpoi):
 
   GENTURTAI = "naljbo"

--- a/transformers/camxes_morphology.py
+++ b/transformers/camxes_morphology.py
@@ -15,7 +15,7 @@ SELMAHO_Y       = "Y"
 
 # flatten and join textual nodes
 def lerpoi(children):
-  return "".join(flatten(children))
+  return "".join(flatten(map(str, children)))
 
 class Transformer:
 


### PR DESCRIPTION
Fixes a bug where the camxes_morphology transformer would try to do something like `"".join(["a", "b", <structures.gensuha.Fuhivla instance>])` and die, by adding a string cast method to `structures.gensuha.Lerpoi`.