### PR TITLE
fix slinku'i/cmevla conflict in vlatai

### DIFF
--- a/parsers/camxes_ilmen.peg
+++ b/parsers/camxes_ilmen.peg
@@ -1496,7 +1496,7 @@ fuhivla_head = ( !rafsi_string brivla_head )
 brivla_head = ( !cmavo !slinkuhi !h &onset unstressed_syllable* )
 
 slinkuhi = ( consonant rafsi_string )
-slinkuhi_no_recurse = ( !lujvo ( consonant rafsi_string ) )
+slinkuhi_no_recurse = ( !cmevla !lujvo ( consonant rafsi_string ) )
 
 rafsi_string = (
   y_less_rafsi*


### PR DESCRIPTION
Fix some erroneous detection of cmevla that sort of look like slinku'i, by adding another negative lookahead to vlatai's slinku'i detector.